### PR TITLE
Port changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.beam
 deps/
 ebin/*.app
-*.swp
-
+log/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+How to run
+==========
+
+```
+rebar get-deps compile
+cp "priv/config.example" "~/.config/etorrent.config"
+./start-dev.sh
+```

--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@ How to run
 ```
 rebar get-deps compile
 cp "priv/config.example" "~/.config/etorrent.config"
+edit "~/.config/etorrent.config"
 ./start-dev.sh
 ```
+
+Go to "http://127.0.0.1:1080/".

--- a/priv/config.example
+++ b/priv/config.example
@@ -1,0 +1,112 @@
+%% -*- mode: Erlang; -*-
+[{etorrent_core,
+  [
+   %% The port entry tells etorrent which port it should listen on. It
+   %% can currently not be limited to listen on certain interfaces
+   %% only. It will instead bind to every available interface present.
+   {port, 1729 },
+
+   %% The port to listen on when retrieving UDP responses from the tracker
+   {udp_port, 1730 },
+
+   %% The dht entry enables the DHT subsystem, it is used to
+   %% retrieve information of which peers are available if there
+   %% are no trackers available.
+   {dht, true },
+
+   %% The DHT subsystem will also bind to all interfaces.
+   {dht_port, 6882 },
+
+   %% The DHT subsystem stores its internal state between runs in a state file
+   %% The following setting defines the location of this file
+   {dht_state, "/home/user/etorrent/spool/dht_state.dets"},
+
+   %% Enable UPnP subsystem, which tries to open port mappings in
+   %% UPnP-aware routers for etorrent.
+   {use_upnp, true },
+
+   %% The directory to watch for .torrent files and the directory to download data into
+   {dir, "/home/user/etorrent/torrent_data"},
+
+   %% The directory to download data into. It is optional, if not defined used 'dir' value.
+   {download_dir, "/home/user/etorrent/torrent_data"},
+
+   %% Interval in seconds to check directory for new .torrent files
+   {dirwatch_interval, 20 },
+
+   %% Location of the log file
+   {logger_dir, "log"},
+
+   %% Name of the log file. Etorrent will stamp out simple messages here whenever progress
+   %% is made in the system.
+   {logger_fname, "etorrent.log"},
+
+   %% Location of the fast resume file. If present this file is used to populate the fast-
+   %% resume table, so startup is much faster. Every 5 minutes the file is stamped out,
+   %% so an eventual death of the system won't affect too much. It is also written upon
+   %% graceful termination.
+   %% NOTE: The directory for the fast resume file must exist, or etorrent will crash.
+   {fast_resume_file, "/home/user/etorrent/spool/fast_resume_state.dets"},
+
+   %% Limit on the number of peers the system can maximally be connected to
+   {max_peers, 200},
+
+   %% The download rate of the system.
+   {max_download_rate, 1200 },
+
+   %% The upload rate of the system.
+   {max_upload_rate, 1200 },
+
+   %% Number of upload slots. Either an integer or 'auto'. We recommend 'auto' as this
+   %% will calculate a sane number of upload slots from the upload_rate. If this is set
+   %% too low, you will not saturate the outbound bandwidth. If set too high, peers will
+   %% not like the client as it can only give bad rates to all peers.
+   {max_upload_slots, auto},
+
+   %% High and low watermarks for the file system processes. Etorrent will not open more
+   %% on-disk files than the limit given here.
+   {fs_watermark_high, 128},
+   {fs_watermark_low, 100},
+
+   %% Number of optimistic upload slots. If your line is really fast, consider increasing
+   %% this a little bit.
+   {min_uploads, 2},
+
+   %% The preallocation strategy to use when creating new files. The default is "sparse"
+   %% which creates a sparse file on the disk. Some file systems are bad at working with
+   %% sparse files, most notably FreeBSDs default file system. The other option here is
+   %% "preallocate" which means the system will fill the file up on disk before using it.
+   {preallocation_strategy, sparse },
+
+   %% Enable the Web user interface in etorrent, on 127.0.0.1:8080
+   {webui, true },
+
+   %% Enable logging in the webui
+   {webui_logger_dir, "log/webui"},
+
+   %% The address to bind the webui on. Notice that is has to be given as a tuple for an IP address
+   %% and as a string for a domain name.
+   {webui_bind_address, {127,0,0,1}},
+
+   %% The port to use for the webui
+   {webui_port, 8080},
+
+   %% Enable profiling; do not enable unless you need it
+   {profiling, false}
+  ]},
+ {lager,
+  [{handlers,
+    [{lager_console_backend, [debug, true]},
+     {lager_file_backend,
+      [{"log/error.log", error, 10485760, "$D0", 5},
+       {"log/console.log", info, 10485760, "$D0", 5},
+       {"log/debug.log", debug, 10485760, "$D0", 5}
+      ]}
+    ]}
+  ]},
+ {kernel,
+         [{start_timer, true}]},
+ {sasl,
+        [{sasl_error_logger, {file, "log/sasl/sasl-error.log"}},
+         {errlog_type, error}]}
+].

--- a/rebar.config
+++ b/rebar.config
@@ -26,5 +26,6 @@
        {meck, ".*", {git, "git://github.com/klaar/meck.git", "file-bif-passthrough"}},
        {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}},
        {cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}},
-       {rlimit, ".*", {git, "git://github.com/jlouis/rlimit.git", "master"}}
+       {rlimit, ".*", {git, "git://github.com/jlouis/rlimit.git", "master"}},
+       {cascadae, ".*", {git, "git://github.com/freeakk/cascadae.git", "master"}}
        ]}.

--- a/src/etorrent_app.erl
+++ b/src/etorrent_app.erl
@@ -16,23 +16,26 @@
 -export([start/2, stop/1, prep_stop/1, profile_output/0]).
 
 -define(RANDOM_MAX_SIZE, 999999999999).
+-define(APP, etorrent_core).
 
 start() ->
     start([]).
 
 start(Config) ->
     load_config(Config),
-    {ok, Deps} = application:get_key(etorrent, applications),
+    % Load app file.
+    application:load(?APP),
+    {ok, Deps} = application:get_key(?APP, applications),
     true = lists:all(fun ensure_started/1, Deps),
-    application:start(etorrent).
+    application:start(?APP).
 
 stop() ->
-    application:stop(etorrent).
+    application:stop(?APP).
 
 load_config([]) ->
     ok;
 load_config([{Key, Val} | Next]) ->
-    application:set_env(etorrent, Key, Val),
+    application:set_env(?APP, Key, Val),
     load_config(Next).
 
 %% @private
@@ -85,6 +88,8 @@ stop(_State) ->
     ok.
 
 start_webui() ->
+    cascadae:start(),
+
     Dispatch = [ {'_', [{'_', etorrent_cowboy_handler, []}]} ],
     {ok, _Pid} =
         cowboy:start_listener(http, 10,

--- a/src/etorrent_chunkset.erl
+++ b/src/etorrent_chunkset.erl
@@ -5,14 +5,18 @@
 -endif.
 
 -export([new/2,
+         new/1,
          size/1,
          min/1,
          min/2,
+         extract/2,
          is_empty/1,
          delete/2,
          delete/3,
          insert/3,
-         from_list/3]).
+         from_list/3,
+         in/3,
+         subtract/3]).
 
 -record(chunkset, {
     piece_len :: pos_integer(),
@@ -31,6 +35,12 @@ new(PieceLen, ChunkLen) ->
         piece_len=PieceLen,
         chunk_len=ChunkLen,
         chunks=[{0, PieceLen - 1}]}.
+
+
+%% @doc Create am empty copy of the chunkset.
+new(Prototype) ->
+    Prototype#chunkset{chunks=[]}.
+
 
 from_list(PieceLen, ChunkLen, Chunks) ->
     #chunkset{
@@ -86,11 +96,88 @@ min_(_, 0) ->
 min_(Chunkset, Numchunks) ->
     case min_(Chunkset) of
         none -> [];
-        {Start, End}=Chunk ->
-            Without = delete(Start, End, Chunkset),
+        {Start, Size}=Chunk ->
+            Without = delete(Start, Size, Chunkset),
             [Chunk|min_(Without, Numchunks - 1)]
     end.
 
+
+%% @doc This operation combines min/2 and delete.
+extract(Chunkset, Numchunks) when Numchunks >= 0 ->
+    extract_(Chunkset, Numchunks, []).
+
+
+extract_(Chunkset, 0, Acc) ->
+    {lists:reverse(Acc), Chunkset, 0};
+
+extract_(Chunkset, Numchunks, Acc) ->
+    case min_(Chunkset) of
+        none -> 
+            {lists:reverse(Acc), Chunkset, Numchunks};
+
+        {Start, Size}=Chunk ->
+            Without = delete(Start, Size, Chunkset),
+            extract_(Without, Numchunks - 1, [Chunk|Acc])
+    end.
+
+
+
+in(Offset, Size, Chunkset) ->
+    NewChunkset = delete(Offset, Size, Chunkset),
+    OldSize = ?MODULE:size(Chunkset),
+    NewSize = ?MODULE:size(NewChunkset),
+    Size =:= (OldSize - NewSize).
+
+
+%% @doc This operation run `delete/3' and return result and 
+%%      the list of the deleted values.
+subtract(Offset, Length, Chunkset) when Length > 0, Offset >= 0 ->
+    #chunkset{chunks=Chunks} = Chunkset,
+    {NewChunks, Deleted} = sub_(Offset, Offset + Length - 1, Chunks, [], []),
+    {Chunkset#chunkset{chunks=NewChunks}, rev_deleted_(Deleted, [])}.
+
+%% E = S + L - 1.
+%% L = E - S + 1.
+rev_deleted_([{S, E}|T], Acc) ->
+    L = E - S + 1,
+    rev_deleted_(T, [{S, L}|Acc]);
+
+rev_deleted_([], Acc) -> Acc.
+
+
+sub_(CS, CE, [{S, E}=H|T], Res, Acc) 
+    when is_integer(S), is_integer(CS), 
+         is_integer(E), is_integer(CE) ->
+    if
+    CS =< S, CE =:= E ->
+        % full match
+        {lists:reverse(Res, T), [H|Acc]}; % H
+    CS =< S, CE < E, CE > S ->
+        % try delete smaller piece
+        {lists:reverse(Res, [{CE+1, E}|T]), [{S, CE}|Acc]};
+    CS =< S, CE < S ->
+        % skip range
+        {lists:reverse(Res, [H|T]), Acc};
+    CS =< S, CE > E ->
+        % try delete bigger piece
+        sub_(E+1, CE, T, Res, [H|Acc]);
+    CS > S, CE =:= E ->
+        % try delete smaller piece
+        {lists:reverse(Res, [{S, CS-1}|T]), [{CS, E}|Acc]};
+    CS > S, CE < E ->
+        % try delete smaller piece
+        {lists:reverse(Res, [{S, CS-1},{CE+1, E}|T]), 
+         [{CS, CE}|Acc]};
+    CS > S, CS < E, CE > E ->
+        % try delete bigger piece
+        sub_(E+1, CE, T, [{S, CS-1}|Res], [{CS, E}|Acc]);
+    CS > E ->
+        % chunk is higher
+        sub_(E+1, CE, T, [H|Res], Acc)
+    end;
+sub_(_CS, _CE, [], Res, Acc) ->
+    {lists:reverse(Res), Acc}.
+    
 
 %% @doc Check is a chunkset is empty
 %% @end
@@ -108,12 +195,16 @@ delete([{Offset, Length}|T], Chunkset) ->
     delete(T, delete(Offset, Length, Chunkset)).
 
 
+insert([], Chunkset) ->
+    Chunkset;
+insert([{Offset, Length}|T], Chunkset) ->
+    insert(T, insert(Offset, Length, Chunkset)).
+
+
 %% @doc
 %% 
 %% @end
-delete(_, Length, _) when Length < 1 ->
-    erlang:error(badarg);
-delete(Offset, _, _) when Offset < 0 ->
+delete(Offset, Length, Chunkset) when Length < 1; Offset < 0 ->
     erlang:error(badarg);
 delete(Offset, Length, Chunkset) ->
     #chunkset{chunks=Chunks} = Chunkset,
@@ -286,5 +377,28 @@ insert_with_middle_test() ->
 insert_past_end_test() ->
     Set0 = ?set:new(32, 2),
     ?assertError(badarg, ?set:insert(0, 33, Set0)).
+
+in_test_() ->
+    Set0 = ?set:from_list(32, 2, [{0, 31}]),
+    Set1 = ?set:from_list(32, 2, [{0, 10}, {20, 31}]),
+    [ ?_assertEqual(true,  ?set:in(5, 6, Set0))
+    , ?_assertEqual(true,  ?set:in(0, 32, Set0))
+    , ?_assertEqual(false, ?set:in(0, 35, Set0))
+    , ?_assertEqual(false, ?set:in(0, 55, Set0))
+
+    , ?_assertEqual(true,  ?set:in(3, 4, Set1))
+    , ?_assertEqual(false, ?set:in(10, 4, Set1))
+    , ?_assertEqual(false, ?set:in(10, 21, Set1))
+    , ?_assertEqual(false, ?set:in(0, 31, Set1))
+    ].
+
+subtract_test_() ->
+    T0 = ?set:from_list(32, 2, [{10, 20}]),
+    T1 = ?set:from_list(32, 2, [{10, 10}, {15, 20}]),
+    T2 = ?set:from_list(32, 2, [{15, 20}]),
+    [ ?_assertEqual(subtract(11, 4, T0), {T1, [{11,4}]})
+    , ?_assertEqual(subtract(5, 10, T0), {T2, [{10,5}]})
+    , ?_assertEqual(subtract(21, 5, T0), {T0, []})
+    ].
 
 -endif.

--- a/src/etorrent_core.app.src
+++ b/src/etorrent_core.app.src
@@ -31,7 +31,7 @@
    ]},
   {applications, [kernel,
                   stdlib,
-                  lager,
+                  compiler, syntax_tools, lager,
                   cowboy,
                   crypto,
                   public_key,

--- a/src/etorrent_cowboy_handler.erl
+++ b/src/etorrent_cowboy_handler.erl
@@ -132,7 +132,8 @@ list_torrents() ->
 		       seeding  -> "sparkline-seed";
 		       leeching -> "sparkline-leech";
 		       endgame  -> "sparkline-leech";
-		       unknown ->  "sparkline-leech"
+		       unknown ->  "sparkline-leech";
+		       paused ->  "sparkline-leech"
 		   end,
 		   show_sparkline(lists:reverse(SL)),
 		   round(lists:max(SL) / 1024),

--- a/src/etorrent_download.erl
+++ b/src/etorrent_download.erl
@@ -1,5 +1,6 @@
 -module(etorrent_download).
 
+
 %% exported functions
 -export([await_servers/1,
          request_chunks/3,
@@ -8,8 +9,14 @@
          chunk_fetched/4,
          chunk_stored/4]).
 
+%% gproc registry entries
+-export([register_server/1,
+         unregister_server/1,
+         lookup_server/1,
+         await_server/1]).
+
 %% update functions
--export([activate_endgame/1,
+-export([switch_assignor/2,
          update/2]).
 
 -type torrent_id()  :: etorrent_types:torrent_id().
@@ -18,19 +25,37 @@
 -type chunk_offset() :: etorrent_types:chunk_offset().
 -type chunk_length() :: etorrent_types:chunk_len().
 -type chunkspec()   :: {pieceindex(), chunk_offset(), chunk_length()}.
+-type update_query() :: {assignor, pid()}.
 
--type tupdate() :: {endgame, boolean()}.
 
 -record(tservices, {
     torrent_id :: torrent_id(),
-    in_endgame :: boolean(),
+    assignor   :: pid(),
     pending    :: pid(),
-    progress   :: pid(),
-    histogram  :: pid(),
-    endgame    :: pid()}).
--define(endgame(Handle), (Handle#tservices.in_endgame)).
+    histogram  :: pid()}).
 -opaque tservices() :: #tservices{}.
 -export_type([tservices/0]).
+
+
+-spec register_server(torrent_id()) -> true.
+register_server(TorrentID) ->
+    etorrent_utils:register(server_name(TorrentID)).
+
+-spec unregister_server(torrent_id()) -> true.
+unregister_server(TorrentID) ->
+    etorrent_utils:unregister(server_name(TorrentID)).
+
+-spec lookup_server(torrent_id()) -> pid().
+lookup_server(TorrentID) ->
+    etorrent_utils:lookup(server_name(TorrentID)).
+
+-spec await_server(torrent_id()) -> pid().
+await_server(TorrentID) ->
+    etorrent_utils:await(server_name(TorrentID)).
+
+server_name(TorrentID) ->
+    {etorrent, TorrentID, assignor}.
+
 
 
 %% @doc
@@ -38,75 +63,58 @@
 -spec await_servers(torrent_id()) -> tservices().
 await_servers(TorrentID) ->
     Pending   = etorrent_pending:await_server(TorrentID),
-    Progress  = etorrent_progress:await_server(TorrentID),
+    Assignor  = await_server(TorrentID),
     Histogram = etorrent_scarcity:await_server(TorrentID),
-    Endgame   = etorrent_endgame:await_server(TorrentID),
-    Inendgame = etorrent_endgame:is_active(Endgame),
     ok = etorrent_pending:register(Pending),
     Handle = #tservices{
         torrent_id=TorrentID,
-        in_endgame=Inendgame,
         pending=Pending,
-        progress=Progress,
-        histogram=Histogram,
-        endgame=Endgame},
+        assignor=Assignor,
+        histogram=Histogram},
     Handle.
 
 
-%% @doc
+%% @doc Run `update/2' for the peer with Pid.
+%%      It allows to change the Hangle tuple.
 %% @end
--spec activate_endgame(pid()) -> ok.
-activate_endgame(Pid) ->
-    Pid ! {download, {endgame, true}},
+-spec switch_assignor(pid(), pid()) -> ok.
+switch_assignor(PeerPid, Assignor) ->
+    PeerPid ! {download, {assignor, Assignor}},
     ok.
 
 
-%% @doc
+%% @doc This function is called by peer.
 %% @end
--spec update(tupdate(), tservices()) -> tservices().
-update({endgame, Inendgame}, Handle) when is_boolean(Inendgame) ->
-    Handle#tservices{in_endgame=Inendgame}.
+-spec update(update_query(), tservices()) -> tservices().
+update({assignor, Assignor}, Handle) when is_pid(Assignor) ->
+    Handle#tservices{assignor=Assignor}.
 
 
 %% @doc
 %% @end
 -spec request_chunks(non_neg_integer(), pieceset(), tservices()) ->
     {ok, assigned | not_interested | [chunkspec()]}.
-request_chunks(Numchunks, Peerset, Handle) when ?endgame(Handle) ->
-    #tservices{endgame=Endgame} = Handle,
-    etorrent_chunkstate:request(Numchunks, Peerset, Endgame);
-
 request_chunks(Numchunks, Peerset, Handle) ->
-    #tservices{progress=Progress} = Handle,
-    etorrent_chunkstate:request(Numchunks, Peerset, Progress).
+    #tservices{assignor=Assignor} = Handle,
+    etorrent_chunkstate:request(Numchunks, Peerset, Assignor).
 
 
 %% @doc
 %% @end
 -spec chunk_dropped(pieceindex(),
                     chunk_offset(), chunk_length(), tservices()) -> ok.
-chunk_dropped(Piece, Offset, Length, Handle) when ?endgame(Handle) ->
-    #tservices{pending=Pending, endgame=Endgame} = Handle,
-    ok = etorrent_chunkstate:dropped(Piece, Offset, Length, self(), Endgame),
-    ok = etorrent_chunkstate:dropped(Piece, Offset, Length, self(), Pending);
-
-chunk_dropped(Piece, Offset, Length, Handle) ->
-    #tservices{pending=Pending, progress=Progress} = Handle,
-    ok = etorrent_chunkstate:dropped(Piece, Offset, Length, self(), Progress),
+chunk_dropped(Piece, Offset, Length, Handle)->
+    #tservices{pending=Pending, assignor=Assignor} = Handle,
+    ok = etorrent_chunkstate:dropped(Piece, Offset, Length, self(), Assignor),
     ok = etorrent_chunkstate:dropped(Piece, Offset, Length, self(), Pending).
 
 
 %% @doc
 %% @end
 -spec chunks_dropped([chunkspec()], tservices()) -> ok.
-chunks_dropped(Chunks, Handle) when ?endgame(Handle) ->
-    #tservices{pending=Pending, endgame=Endgame} = Handle,
-    ok = etorrent_chunkstate:dropped(Chunks, self(), Endgame),
-    ok = etorrent_chunkstate:dropped(Chunks, self(), Pending);
-
 chunks_dropped(Chunks, Handle) ->
-    #tservices{pending=Pending, progress=Progress} = Handle,
-    ok = etorrent_chunkstate:dropped(Chunks, self(), Progress),
+    #tservices{pending=Pending, assignor=Assignor} = Handle,
+    ok = etorrent_chunkstate:dropped(Chunks, self(), Assignor),
     ok = etorrent_chunkstate:dropped(Chunks, self(), Pending).
 
 
@@ -114,12 +122,9 @@ chunks_dropped(Chunks, Handle) ->
 %% @end
 -spec chunk_fetched(pieceindex(),
                     chunk_offset(), chunk_length(), tservices()) -> ok.
-chunk_fetched(Piece, Offset, Length, Handle) when ?endgame(Handle) ->
-    #tservices{endgame=Endgame} = Handle,
-    ok = etorrent_chunkstate:fetched(Piece, Offset, Length, self(), Endgame);
-
-chunk_fetched(_, _, _, _) ->
-    ok.
+chunk_fetched(Piece, Offset, Length, Handle) ->
+    #tservices{assignor=Assignor} = Handle,
+    ok = etorrent_chunkstate:fetched(Piece, Offset, Length, self(), Assignor).
 
 
 %% @doc
@@ -128,6 +133,6 @@ chunk_fetched(_, _, _, _) ->
                    chunk_offset(), chunk_length(), tservices())
                   -> ok.
 chunk_stored(Piece, Offset, Length, Handle) ->
-    #tservices{pending=Pending, progress=Progress} = Handle,
-    ok = etorrent_chunkstate:stored(Piece, Offset, Length, self(), Progress),
+    #tservices{pending=Pending, assignor=Assignor} = Handle,
+    ok = etorrent_chunkstate:stored(Piece, Offset, Length, self(), Assignor),
     ok = etorrent_chunkstate:stored(Piece, Offset, Length, self(), Pending).

--- a/src/etorrent_event.erl
+++ b/src/etorrent_event.erl
@@ -10,15 +10,22 @@
 
 %% Installation/deinstallation of the event mgr
 -export([start_link/0,
-	 add_handler/2,
-	 delete_handler/2]).
+	     add_handler/2,
+	     delete_handler/2]).
 
-%% Notifications
+%% Torrent Notifications
 -export([notify/1,
          started_torrent/1,
+         stopped_torrent/1,
          checking_torrent/1,
-	 completed_torrent/1,
+	     completed_torrent/1,
          seeding_torrent/1]).
+
+%% Task Notifications
+-export([added_task/1,
+         completed_task/1,
+         failed_task/2]).
+
 
 -define(SERVER, ?MODULE).
 %% =======================================================================
@@ -42,6 +49,10 @@ add_handler(Handler, Args) ->
 delete_handler(Handler, Args) ->
     gen_event:delete_handler(?SERVER, Handler, Args).
 
+%% @equiv notify({stopped_torrent, Id})
+-spec stopped_torrent(integer()) -> ok.
+stopped_torrent(Id) -> notify({stopped_torrent, Id}).
+
 %% @equiv notify({started_torrent, Id})
 -spec started_torrent(integer()) -> ok.
 started_torrent(Id) -> notify({started_torrent, Id}).
@@ -57,6 +68,11 @@ seeding_torrent(Id) -> notify({seeding_torrent, Id}).
 %% @equiv notify({completed_torrent, Id})
 -spec completed_torrent(integer()) -> ok.
 completed_torrent(Id) -> notify({completed_torrent, Id}).
+
+%% @doc New task was added.
+added_task(Props) -> notify({added_task, Props}).
+completed_task(Props) -> notify({completed_task, Props}).
+failed_task(Props, Reason) -> notify({failed_task, Props, Reason}).
 
 %% ====================================================================
 

--- a/src/etorrent_info.erl
+++ b/src/etorrent_info.erl
@@ -1,0 +1,682 @@
+% @author Uvarov Michail <freeakk@gmail.com>
+
+-module(etorrent_info).
+-behaviour(gen_server).
+
+-define(AWAIT_TIMEOUT, 10*1000).
+-define(DEFAULT_CHUNK_SIZE, 16#4000). % TODO - get this value from a configuration file
+
+
+-export([start_link/2,
+         register_server/1,
+         lookup_server/1,
+         await_server/1]).
+
+-export([get_mask/2,
+         get_mask/4,
+         tree_children/2,
+         minimize_filelist/2]).
+
+%% Info API
+-export([long_file_name/2,
+         file_name/2,
+         full_file_name/2,
+         file_position/2,
+         file_size/2,         %
+         piece_size/1,        %
+         piece_count/1,       %
+         chunk_size/1         %
+        ]).
+
+
+-export([init/1,
+         handle_call/3,
+         terminate/2,
+         code_change/3]).
+
+
+-type block_len() :: etorrent_types:block_len().
+-type block_offset() :: etorrent_types:block_offset().
+-type bcode() :: etorrent_types:bcode().
+-type piece_bin() :: etorrent_types:piece_bin().
+-type chunk_len() :: etorrent_types:chunk_len().
+-type chunk_offset() :: etorrent_types:chunk_offset().
+-type chunk_bin() :: etorrent_types:chunk_bin().
+-type piece_index() :: etorrent_types:piece_index().
+-type file_path() :: etorrent_types:file_path().
+-type torrent_id() :: etorrent_types:torrent_id().
+-type file_id() :: etorrent_types:file_id().
+-type block_pos() :: {string(), block_offset(), block_len()}.
+-type pieceset() :: etorrent_pieceset:pieceset().
+
+-record(io_file, {
+    rel_path :: file_path(),
+    process  :: pid(),
+    monitor  :: reference(),
+    accessed :: {integer(), integer(), integer()}}).
+
+
+-record(state, {
+    torrent :: torrent_id(),
+    static_file_info :: array(),
+    total_size :: non_neg_integer(),
+    piece_size :: non_neg_integer(),
+    chunk_size = ?DEFAULT_CHUNK_SIZE :: non_neg_integer(),
+    piece_count :: non_neg_integer()
+    }).
+
+
+-record(file_info, {
+    id :: file_id(),
+    %% Relative name, used in file_sup
+    name :: string(),
+    %% Label for nodes of cascadae file tree
+    short_name :: binary(),
+    type      = file :: directory | file,
+    children  = [] :: [file_id()],
+    % How many files are in this node?
+    capacity  = 0 :: non_neg_integer(),
+    size      = 0 :: non_neg_integer(),
+    % byte offset from 0
+    position  = 0 :: non_neg_integer(),
+    pieces :: array()
+}).
+
+-type file_info() :: #file_info{}.
+
+
+%% @doc Start the File I/O Server
+%% @end
+-spec start_link(torrent_id(), bcode()) -> {'ok', pid()}.
+start_link(TorrentID, Torrent) ->
+    gen_server:start_link(?MODULE, [TorrentID, Torrent], [{timeout,15000}]).
+
+
+
+server_name(TorrentID) ->
+    {etorrent, TorrentID, info}.
+
+
+%% @doc
+%% Register the current process as the directory server for
+%% the given torrent.
+%% @end
+-spec register_server(torrent_id()) -> true.
+register_server(TorrentID) ->
+    etorrent_utils:register(server_name(TorrentID)).
+
+%% @doc
+%% Lookup the process id of the directory server responsible
+%% for the given torrent. If there is no such server registered
+%% this function will crash.
+%% @end
+-spec lookup_server(torrent_id()) -> pid().
+lookup_server(TorrentID) ->
+    etorrent_utils:lookup(server_name(TorrentID)).
+
+%% @doc
+%% Wait for the directory server for this torrent to appear
+%% in the process registry.
+%% @end
+-spec await_server(torrent_id()) -> pid().
+await_server(TorrentID) ->
+    etorrent_utils:await(server_name(TorrentID), ?AWAIT_TIMEOUT).
+
+
+
+%% @doc Build a mask of the file in the torrent.
+-spec get_mask(torrent_id(), file_id()) -> pieceset().
+get_mask(TorrentID, FileID) when is_integer(FileID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Mask} = gen_server:call(DirPid, {get_mask, FileID}),
+    Mask;
+
+%% List of files with same priority.
+get_mask(TorrentID, [_|_] = IdList) ->
+    true = lists:all(fun is_integer/1, IdList),
+    DirPid = await_server(TorrentID),
+    MapFn = fun(FileID) ->
+            {ok, Mask} = gen_server:call(DirPid, {get_mask, FileID}),
+            Mask
+        end,
+
+    %% Do map
+    Masks = lists:map(MapFn, IdList),
+    %% Do reduce
+    etorrent_pieceset:union(Masks).
+   
+ 
+%% @doc Build a mask of the part of the file in the torrent.
+get_mask(TorrentID, FileID, PartStart, PartSize)
+    when PartStart >= 0, PartSize >= 0, 
+            is_integer(TorrentID), is_integer(FileID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Mask} = gen_server:call(DirPid, {get_mask, FileID, PartStart, PartSize}),
+    Mask.
+
+
+piece_size(TorrentID) when is_integer(TorrentID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Size} = gen_server:call(DirPid, piece_size),
+    Size.
+
+
+chunk_size(TorrentID) when is_integer(TorrentID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Size} = gen_server:call(DirPid, chunk_size),
+    Size.
+
+
+piece_count(TorrentID) when is_integer(TorrentID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Count} = gen_server:call(DirPid, piece_count),
+    Count.
+
+
+file_position(TorrentID, FileID) when is_integer(TorrentID), is_integer(FileID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Pos} = gen_server:call(DirPid, {position, FileID}),
+    Pos.
+
+
+file_size(TorrentID, FileID) when is_integer(TorrentID), is_integer(FileID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Size} = gen_server:call(DirPid, {size, FileID}),
+    Size.
+
+
+-spec tree_children(torrent_id(), file_id()) -> [{atom(), term()}].
+tree_children(TorrentID, FileID) when is_integer(TorrentID), is_integer(FileID) ->
+    %% get children
+    DirPid = await_server(TorrentID),
+    {ok, Records} = gen_server:call(DirPid, {tree_children, FileID}),
+
+    %% get valid pieceset
+    CtlPid = etorrent_torrent_ctl:lookup_server(TorrentID),    
+    {ok, Valid} = etorrent_torrent_ctl:valid_pieces(CtlPid),
+
+    lists:map(fun(X) ->
+            ValidFP = etorrent_pieceset:intersection(X#file_info.pieces, Valid),
+            SizeFP = etorrent_pieceset:size(X#file_info.pieces),
+            ValidSizeFP = etorrent_pieceset:size(ValidFP),
+            [{id, X#file_info.id}
+            ,{name, X#file_info.short_name}
+            ,{size, X#file_info.size}
+            ,{capacity, X#file_info.capacity}
+            ,{is_leaf, (X#file_info.children == [])}
+            ,{progress, ValidSizeFP / SizeFP}
+            ]
+        end, Records).
+    
+
+%% @doc Form minimal version of the filelist with the same pieceset.
+minimize_filelist(TorrentID, FileIds) when is_integer(TorrentID) ->
+    SortedFiles = lists:sort(FileIds),
+    DirPid = await_server(TorrentID),
+    {ok, Ids} = gen_server:call(DirPid, {minimize_filelist, SortedFiles}),
+    Ids.
+    
+
+%% @doc This name is used in cascadae wish view.
+-spec long_file_name(torrent_id(), file_id() | [file_id()]) -> binary().
+long_file_name(TorrentID, FileID) when is_integer(FileID) ->
+    long_file_name(TorrentID, [FileID]);
+
+long_file_name(TorrentID, FileID) when is_list(FileID), is_integer(TorrentID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Name} = gen_server:call(DirPid, {long_file_name, FileID}),
+    Name.
+
+
+full_file_name(TorrentID, FileID) when is_integer(FileID), is_integer(TorrentID) ->
+    RelName = etorrent_io:file_name(TorrentID, FileID),
+    FileServer = etorrent_io:lookup_file_server(TorrentID, RelName),
+    {ok, Name} = etorrent_io_file:full_path(FileServer),
+    Name.
+
+
+%% @doc Convert FileID to relative file name.
+file_name(TorrentID, FileID) when is_integer(FileID) ->
+    DirPid = await_server(TorrentID),
+    {ok, Name} = gen_server:call(DirPid, {file_name, FileID}),
+    Name.
+    
+
+%% ----------------------------------------------------------------------
+
+%% @private
+init([TorrentID, Torrent]) ->
+    Info = collect_static_file_info(Torrent),
+
+    {Static, PLen, TLen} = Info,
+
+    true = register_server(TorrentID),
+    
+    InitState = #state{
+        torrent=TorrentID,
+        static_file_info=Static,
+        total_size=TLen, 
+        piece_size=PLen,
+        piece_count=(TLen div PLen) + 
+            (case TLen rem PLen of 0 -> 0; _ -> 1 end) 
+    },
+    {ok, InitState}.
+
+
+%% @private
+
+handle_call({get_info, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        X=#file_info{} ->
+            {reply, {ok, X}, State}
+    end;
+
+handle_call({position, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        #file_info{position=P} ->
+            {reply, {ok, P}, State}
+    end;
+
+handle_call({size, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        #file_info{size=Size} ->
+            {reply, {ok, Size}, State}
+    end;
+
+handle_call(chunk_size, _, State=#state{chunk_size=S}) ->
+    {reply, {ok, S}, State};
+
+handle_call(piece_size, _, State=#state{piece_size=S}) ->
+    {reply, {ok, S}, State};
+
+handle_call(piece_count, _, State=#state{piece_count=C}) ->
+    {reply, {ok, C}, State};
+
+handle_call({get_mask, FileID, PartStart, PartSize}, _, State) ->
+    #state{static_file_info=Arr, total_size=TLen, piece_size=PLen} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        #file_info {position = FileStart, size = FileSize} ->
+            %% true = PartSize =< FileSize,
+
+            %% Start from beginning of the torrent
+            From = FileStart + PartStart,
+            To = From + PartSize,
+            Mask = make_mask(From, To, PLen, TLen),
+            Set = etorrent_pieceset:from_bitstring(Mask),
+
+            {reply, {ok, Set}, State}
+    end;
+    
+handle_call({get_mask, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        #file_info {pieces = Mask} ->
+            {reply, {ok, Mask}, State}
+    end;
+
+handle_call({long_file_name, FileIDs}, _, State) ->
+    #state{static_file_info=Arr} = State,
+
+    F = fun(FileID) -> 
+            Rec = array:get(FileID, Arr), 
+            Rec#file_info.name
+       end,
+
+    Reply = try 
+        NameList = lists:map(F, FileIDs),
+        NameBinary = list_to_binary(string:join(NameList, ", ")),
+        {ok, NameBinary}
+        catch error:_ ->
+            lager:error("List of ids ~w caused an error.", 
+                [FileIDs]),
+            {error, badid}
+        end,
+            
+    {reply, Reply, State};
+
+handle_call({file_name, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+    undefined ->
+       {reply, {error, badid}, State};
+    #file_info {name = Name} ->
+       {reply, {ok, Name}, State}
+    end;
+
+handle_call({minimize_filelist, FileIDs}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    RecList = [ array:get(FileID, Arr) || FileID <- FileIDs ],
+    FilteredIDs = [Rec#file_info.id || Rec <- minimize_reclist(RecList)],
+    {reply, {ok, FilteredIDs}, State};
+
+handle_call({tree_children, FileID}, _, State) ->
+    #state{static_file_info=Arr} = State,
+    case array:get(FileID, Arr) of
+        undefined ->
+            {reply, {error, badid}, State};
+        #file_info {children = Ids} ->
+            Children = [array:get(Id, Arr) || Id <- Ids],
+            {reply, {ok, Children}, State}
+    end.
+
+
+
+%% @private
+terminate(_, _) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ----------------------------------------------------------------------
+
+
+
+%% -\/-----------------FILE INFO API----------------------\/-
+%% @private
+collect_static_file_info(Torrent) ->
+    PieceLength = etorrent_metainfo:get_piece_length(Torrent),
+    FileLengths = etorrent_metainfo:file_path_len(Torrent),
+    CurrentDirectory = "",
+    Acc = [],
+    Pos = 0,
+    %% Rec1, Rec2, .. are lists of nodes.
+    %% Calculate positions, create records. They are still not prepared.
+    {TLen, Rec1} = flen_to_record(FileLengths, Pos, Acc),
+    %% Add directories as additional nodes.
+    Rec2 = add_directories(Rec1),
+    %% Fill `pieces' field.
+    %% A mask is a set of pieces which contains the file.
+    Rec3 = fill_pieces(Rec2, PieceLength, TLen),
+    Rec4 = fill_ids(Rec3),
+    {array:from_list(Rec4), PieceLength, TLen}.
+
+
+%% @private
+flen_to_record([{Name, FLen} | T], From, Acc) ->
+    To = From + FLen,
+    X = #file_info {
+        type = file,
+        name = Name,
+        position = From,
+        size = FLen
+    },
+    flen_to_record(T, To, [X|Acc]);
+
+flen_to_record([], TotalLen, Acc) ->
+    {TotalLen+1, lists:reverse(Acc)}.
+
+
+%% @private
+add_directories(Rec1) ->
+    Idx = 1,
+    {Rec2, Children, Idx1, []} = add_directories_(Rec1, Idx, "", [], []),
+    [Last|_] = Rec2,
+    Rec3 = lists:reverse(Rec2),
+
+    #file_info {
+        size = LastSize,
+        position = LastPos
+    } = Last,
+
+    Root = #file_info {
+        name = "",
+        % total size
+        size = (LastSize + LastPos),
+        position = 0,
+        children = Children,
+        capacity = Idx1 - Idx
+    },
+
+    [Root|Rec3].
+
+
+%% "test/t1.txt"
+%% "t2.txt"
+%% "dir1/dir/x.x"
+%% ==>
+%% "."
+%% "test"
+%% "test/t1.txt"
+%% "t2.txt"
+%% "dir1"
+%% "dir1/dir"
+%% "dir1/dir/x.x"
+
+%% @private
+dirname_(Name) ->
+    case filename:dirname(Name) of
+        "." -> "";
+        Dir -> Dir
+    end.
+
+%% @private
+first_token_(Path) ->
+    case filename:split(Path) of
+    ["/", Token | _] -> Token;
+    [Token | _] -> Token
+    end.
+
+%% @private
+file_join_(L, R) ->
+    case filename:join(L, R) of
+        "/" ++ X -> X;
+        X -> X
+    end.
+
+file_prefix_(S1, S2) ->
+    lists:prefix(filename:split(S1), filename:split(S2)).
+
+
+%% @private
+add_directories_([], Idx, Cur, Children, Acc) ->
+    {Acc, lists:reverse(Children), Idx, []};
+
+%% @private
+add_directories_([H|T], Idx, Cur, Children, Acc) ->
+    #file_info{ name = Name, position = CurPos } = H,
+    Dir = dirname_(Name),
+    Action = case Dir of
+            Cur -> 'equal';
+            _   ->
+                case file_prefix_(Cur, Dir) of
+                    true -> 'prefix';
+                    false -> 'other'
+                end
+        end,
+
+    case Action of
+        %% file is in the same directory
+        'equal' ->
+            add_directories_(T, Idx+1, Dir, [Idx|Children], [H|Acc]);
+
+        %% file is in child directory
+        'prefix' ->
+            Sub = Dir -- Cur,
+            Part = first_token_(Sub),
+            NextDir = file_join_(Cur, Part),
+
+            {SubAcc, SubCh, Idx1, SubT} 
+                = add_directories_([H|T], Idx+1, NextDir, [], []),
+            [#file_info{ position = LastPos, size = LastSize }|_] = SubAcc,
+
+            DirRec = #file_info {
+                name = NextDir,
+                size = (LastPos + LastSize - CurPos),
+                position = CurPos,
+                children = SubCh,
+                capacity = Idx1 - Idx
+            },
+            NewAcc = SubAcc ++ [DirRec|Acc],
+            add_directories_(SubT, Idx1, Cur, [Idx|Children], NewAcc);
+        
+        %% file is in the other directory
+        'other' ->
+            {Acc, lists:reverse(Children), Idx, [H|T]}
+    end.
+
+
+%% @private
+fill_pieces(RecList, PLen, TLen) ->
+    F = fun(#file_info{position = From, size = Size} = Rec) ->
+            To = From + Size,
+            Mask = make_mask(From, To, PLen, TLen),
+            Set = etorrent_pieceset:from_bitstring(Mask),
+            Rec#file_info{pieces = Set}
+        end,
+        
+    lists:map(F, RecList).    
+
+
+fill_ids(RecList) ->
+    fill_ids_(RecList, 0, []).
+
+
+fill_ids_([H1=#file_info{name=Name}|T], Id, Acc) ->
+    % set id, prepare name for cascadae
+    H2 = H1#file_info{
+        id = Id,
+        short_name = list_to_binary(filename:basename(Name))
+    },
+    fill_ids_(T, Id+1, [H2|Acc]);
+fill_ids_([], _Id, Acc) ->
+    lists:reverse(Acc).
+
+
+%% @private
+make_mask(From, To, PLen, TLen) 
+    when PLen =< TLen, From =< To, 
+           To  < TLen, From >= 0 ->
+    %% __Bytes__: 1 <= From <= To <= TLen
+    %%
+    %% Calculate how many __pieces__ before, in and after the file.
+    %% Be greedy: when the file ends inside a piece, then put this piece
+    %% both into this file and into the next file.
+    %% [0..X1 ) [X1..X2] (X2..MaxPieces]
+    %% [before) [  in  ] (    after    ]
+    PTotal   = (TLen div PLen)  
+             + case TLen rem PLen of 0 -> 0; _ -> 1 end,
+
+    %% indexing from 0
+    PFrom = From div PLen,
+    PTo   = To   div PLen,
+
+    PBefore = PFrom,
+    PIn     = PTo - PFrom + 1,
+    PAfter  = PTotal - PFrom - PIn,
+    <<0:PBefore, (bnot 0):PIn, 0:PAfter>>.
+
+
+%% @private
+minimize_reclist(RecList) ->
+    minimize_(RecList, []).
+
+
+minimize_([H|T], []) ->
+    minimize_(T, [H]);
+
+
+%% H is a ancestor of the previous element. Skip H.
+minimize_([H=#file_info{position=Pos}|T], 
+    [#file_info{size=PrevSize, position=PrevPos}|_] = Acc)
+    when Pos < (PrevPos + PrevSize) ->
+    minimize_(T, Acc);
+
+minimize_([H|T], Acc) ->
+    minimize_(T, [H|Acc]);
+
+minimize_([], Acc) ->
+    lists:reverse(Acc).
+    
+    
+%% -/\-----------------FILE INFO API----------------------/\-
+
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+make_mask_test_() ->
+    F = fun make_mask/4,
+    % make_index(From, To, PLen, TLen)
+    [?_assertEqual(F(2, 5,  4, 10), <<2#110:3>>)
+    ,?_assertEqual(F(2, 5,  3, 10), <<2#1100:4>>)
+    ,?_assertEqual(F(2, 5,  2, 10), <<2#01100:5>>)
+    ,?_assertEqual(F(2, 5,  1, 10), <<2#0011110000:10>>)
+    ,?_assertEqual(F(2, 5, 10, 10), <<1:1>>)
+    ,?_assertEqual(F(2, 5,  9, 10), <<1:1, 0:1>>)
+    ,?_assertEqual(F(0, 5,  3, 10), <<2#1100:4>>)
+    ,?_assertEqual(F(8, 9,  3, 10), <<2#0011:4>>)
+    ].
+
+add_directories_test_() ->
+    Rec = add_directories(
+        [#file_info{position=0, size=3, name="test/t1.txt"}
+        ,#file_info{position=3, size=2, name="t2.txt"}
+        ,#file_info{position=5, size=1, name="dir1/dir/x.x"}
+        ,#file_info{position=6, size=2, name="dir1/dir/x.y"}
+        ]),
+    Names = el(Rec, #file_info.name),
+    Sizes = el(Rec, #file_info.size),
+    Positions = el(Rec, #file_info.position),
+    Children  = el(Rec, #file_info.children),
+
+    [Root|Elems] = Rec,
+    MinNames  = el(minimize_reclist(Elems), #file_info.name),
+    
+    %% {NumberOfFile, Name, Size, Position, ChildNumbers}
+    List = [{0, "",             8, 0, [1, 3, 4]}
+           ,{1, "test",         3, 0, [2]}
+           ,{2, "test/t1.txt",  3, 0, []}
+           ,{3, "t2.txt",       2, 3, []}
+           ,{4, "dir1",         3, 5, [5]}
+           ,{5, "dir1/dir",     3, 5, [6, 7]}
+           ,{6, "dir1/dir/x.x", 1, 5, []}
+           ,{7, "dir1/dir/x.y", 2, 6, []}
+        ],
+    ExpNames = el(List, 2),
+    ExpSizes = el(List, 3),
+    ExpPositions = el(List, 4),
+    ExpChildren  = el(List, 5),
+    
+    [?_assertEqual(Names, ExpNames)
+    ,?_assertEqual(Sizes, ExpSizes)
+    ,?_assertEqual(Positions, ExpPositions)
+    ,?_assertEqual(Children,  ExpChildren)
+    ,?_assertEqual(MinNames, ["test", "t2.txt", "dir1"])
+    ].
+
+
+el(List, Pos) ->
+    Children  = [element(Pos, X) || X <- List].
+
+
+
+add_directories_test() ->
+    add_directories(
+        [#file_info{position=0, size=3, name=
+    "BBC.7.BigToe/Eoin Colfer. Artemis Fowl/artemis_04.mp3"}
+        ,#file_info{position=3, size=2, name=
+    "BBC.7.BigToe/Eoin Colfer. Artemis Fowl. The Arctic Incident/artemis2_03.mp3"}
+        ]).
+
+% H = {file_info,undefined,
+%           "BBC.7.BigToe/Eoin Colfer. Artemis Fowl. The Arctic Incident/artemis2_03.mp3",
+%           undefined,file,[],0,5753284,1633920175,undefined}
+% NextDir =  "BBC.7.BigToe/Eoin Colfer. Artemis Fowl/. The Arctic Incident
+
+-endif.

--- a/src/etorrent_io_sup.erl
+++ b/src/etorrent_io_sup.erl
@@ -29,7 +29,7 @@ init([TorrentID, Torrent]) ->
     DirServer = directory_server_spec(TorrentID, Torrent),
     Dldir     = etorrent_config:download_dir(),
     FileSup   = file_server_sup_spec(TorrentID, Dldir, Files),
-    {ok, {{one_for_one, 1, 60}, [DirServer, FileSup]}}.
+    {ok, {{one_for_one, 1, 60}, [FileSup, DirServer]}}.
 
 %% ----------------------------------------------------------------------
 directory_server_spec(TorrentID, Torrent) ->

--- a/src/etorrent_sup.erl
+++ b/src/etorrent_sup.erl
@@ -43,6 +43,8 @@ init([PeerId]) ->
     FastResume   = ?CHILD(etorrent_fast_resume),
     PeerStates   = ?CHILD(etorrent_peer_states),
     Choker       = ?CHILD(etorrent_choker),
+    Tasks        = ?CHILD(etorrent_tasks),
+
     Listener     = {etorrent_listen_sup,
                     {etorrent_listen_sup, start_link, [PeerId]},
                     permanent, infinity, supervisor, [etorrent_listen_sup]},
@@ -83,7 +85,7 @@ init([PeerId]) ->
            FastResume, PeerStates,
            Choker, Listener,
            UdpTracking, TorrentPool, Ctl,
-           DirWatcherSup] ++ DHTSup ++ UPNPSup}}.
+           DirWatcherSup, Tasks] ++ DHTSup ++ UPNPSup}}.
 
 
 

--- a/src/etorrent_tasks.erl
+++ b/src/etorrent_tasks.erl
@@ -1,0 +1,121 @@
+-module(etorrent_tasks).
+-define(SERVER, ?MODULE).
+-define(TABLE, ?MODULE).
+
+%% API for retriving information
+-behaviour(gen_server).
+
+-export([ lookup_tasks/0
+
+        , lookup_tracks/1
+        , lookup_tracks/2
+        , reg_tracks/2
+
+        , lookup_track_extractor/3
+        , reg_track_extractor/3
+        ]).
+
+
+%% Supervisor's callbacks
+-export([start_link/0]).
+
+%% Behaviour API
+-export([init/1,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-type torrent_id() :: integer().
+-type file_id() :: integer().
+-type track_id() :: integer().
+
+
+lookup_tasks() ->
+    gproc:lookup_local_properties(tasks).
+
+
+-spec lookup_tracks(torrent_id()) -> [{file_id(), pid()}].
+lookup_tracks(Tid) ->
+    gproc:lookup_local_properties({file_tracks, Tid}).
+
+
+-spec lookup_tracks(torrent_id(), file_id()) -> pid().
+lookup_tracks(Tid, Fid) ->
+    gproc:lookup_local_name({file_tracks, Tid, Fid}).
+
+
+-spec reg_tracks(torrent_id(), file_id()) -> ok.
+reg_tracks(Tid, Fid) ->
+    gproc:add_local_name({file_tracks, Tid, Fid}),
+    gproc:add_local_property({file_tracks, Tid}, Fid),
+    Props = [ {type, file_tracks}
+            , {torrent_id, Tid}
+            , {file_id, Fid}],
+    add_task(Props),
+    ok.
+
+
+
+-spec lookup_track_extractor(torrent_id(), file_id(), track_id()) -> pid().
+lookup_track_extractor(TorrentId, FileId, TrackId) ->
+    gproc:lookup_local_name({file_track_extractor, TorrentId, FileId, TrackId}).
+
+
+-spec reg_track_extractor(torrent_id(), file_id(), track_id()) -> ok.
+reg_track_extractor(TorrentId, FileId, TrackId) ->
+    gproc:add_local_name({file_track_extractor, TorrentId, FileId, TrackId}),
+    Props = [ {type, file_track_extractor}
+            , {torrent_id, TorrentId}
+            , {file_id, FileId}
+            , {track_id, TrackId}],
+    add_task(Props),
+    ok.
+
+
+
+add_task(Props) ->
+    gproc:add_local_property(tasks, Props),
+    gen_server:cast(?SERVER, {reg, self(), Props}).
+
+
+% ------------------------------------------------------------------------    
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-record(state, {
+    table :: integer()
+}).
+
+init([]) ->
+    E = ets:new(?TABLE,[]),
+    {ok, #state{table=E}}.
+
+
+handle_cast({reg, Pid, Props}, State=#state{table=E}) ->
+    etorrent_event:added_task(Props),
+    Ref = erlang:monitor(process, Pid),
+    true = ets:insert_new(E, {Ref, Props}),
+    {noreply, State}.
+
+
+handle_info({'DOWN',Ref,process,_Pid,Reason}, State=#state{table=E}) ->
+    Props = ets:lookup_element(E, Ref, 2),
+    true = ets:delete(E, Ref),
+    case Reason of
+        normal ->
+            etorrent_event:completed_task(Props);
+        _Error ->
+            etorrent_event:failed_task(Props, Reason)
+    end,
+    {noreply, State}.
+
+
+terminate(_, _) ->
+    ok.
+
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/etorrent_torrent.erl
+++ b/src/etorrent_torrent.erl
@@ -18,7 +18,7 @@
                    missing :: non_neg_integer()}). % Number of missing pieces
 %% API
 -export([start_link/0,
-         new/3, all/0, statechange/2,
+         new/2, all/0, statechange/2,
          num_pieces/1, decrease_not_fetched/1,
          is_seeding/1, seeding/0,
          lookup/1, is_endgame/1,
@@ -28,7 +28,7 @@
          handle_info/2, terminate/2]).
 
 %% The type of torrent records.
--type(torrent_state() :: 'leeching' | 'seeding' | 'endgame' | 'unknown').
+-type(torrent_state() :: 'leeching' | 'seeding' | 'endgame' | 'paused' | 'unknown').
 
 %% A single torrent is represented as the 'torrent' record
 -record(torrent,
@@ -74,18 +74,33 @@ start_link() ->
 %%   state as given. Pieces is the number of pieces for this torrent.
 %% </p>
 %% <p><emph>Precondition:</emph> The #piece table has been filled with the torrents pieces.</p>
+
+%%  Info is a proplist:
+%%
+%%  ```
+%% [{uploaded, integer()},
+%%  {downloaded, integer()},
+%%  {all_time_uploaded, non_neg_integer()},
+%%  {all_time_downloaded, non_neg_integer()},
+%%  {left, integer()},
+%%  {total, integer()},
+%%  {is_private, boolean()},
+%%  {pieces, integer()},
+%%  {missing, integer()},
+%%  {state, atom()}]
+%% '''
+%%
 %% @end
 -spec new(integer(),
-       {{uploaded, integer()},
-        {downloaded, integer()},
-        {all_time_uploaded, non_neg_integer()},
-        {all_time_downloaded, non_neg_integer()},
-        {left, integer()},
-        {total, integer()},
-        {is_private, boolean()},
-        {pieces, etorrent_pieceset:pieceset()}}, integer()) -> ok.
-new(Id, Info, NPieces) ->
-    gen_server:call(?SERVER, {new, Id, Info, NPieces}).
+       [{atom(), term()}]) -> ok.
+new(Id, PL) ->
+    T = props_to_record(Id, PL),
+
+    Missing = proplists:get_value(missing, PL),
+    P = #c_pieces{ id = Id, missing = Missing},
+
+    gen_server:call(?SERVER, {new, Id, T, P}).
+
 
 %% @doc Return all torrents, sorted by Id
 %% @end
@@ -179,46 +194,32 @@ init([]) ->
 		      rate_sparkline_update),
     {ok, #state{ monitoring = dict:new() }}.
 
+
 %% @private
-handle_call({new, Id, {{uploaded, U}, {downloaded, D},
-		               {all_time_uploaded, AU},
-		               {all_time_downloaded, AD},
-                       {left, L}, {total, T}, {is_private, P},
-                       {pieces, Valid}},
-                       NPieces}, {Pid, _Tag}, S) ->
-    State = case L of
-                0 -> etorrent_event:seeding_torrent(Id),
-                     seeding;
-                _ -> leeching
-            end,
-    true = ets:insert_new(?TAB,
-                #torrent { id = Id,
-                           left = L,
-                           total = T,
-                           uploaded = U,
-                           downloaded = D,
-			               all_time_uploaded = AU,
-			               all_time_downloaded = AD,
-                           pieces = NPieces,
-                           is_private = P,
-                           state = State }),
-    Missing = NPieces - etorrent_pieceset:size(Valid),
-    true = ets:insert_new(etorrent_c_pieces, #c_pieces{ id = Id, missing = Missing}),
+%% @todo Avoid downs. Let the called process die.
+handle_call({new, Id, T=#torrent{}, P=#c_pieces{}},  {Pid, _Tag},  S) ->
+    true = ets:insert_new(?TAB, T),
+    true = ets:insert_new(etorrent_c_pieces,  P),
+
     R = erlang:monitor(process, Pid),
     NS = S#state { monitoring = dict:store(R, Id, S#state.monitoring) },
     {reply, ok, NS};
+
 handle_call(all, _F, S) ->
     Q = all(#torrent.id),
     {reply, Q, S};
+
 handle_call({num_pieces, Id}, _F, S) ->
     Reply = case ets:lookup(?TAB, Id) of
 		[R] -> {value, R#torrent.pieces};
 		[] ->  not_found
 	    end,
     {reply, Reply, S};
+
 handle_call({statechange, Id, What}, _F, S) ->
     Q = state_change(Id, What),
     {reply, Q, S};
+
 handle_call({decrease, Id}, _F, S) ->
     N = ets:update_counter(etorrent_c_pieces, Id, {#c_pieces.missing, -1}),
     case N of
@@ -228,12 +229,15 @@ handle_call({decrease, Id}, _F, S) ->
         N when is_integer(N) ->
             {reply, ok, S}
     end;
+
 handle_call(_M, _F, S) ->
     {noreply, S}.
+
 
 %% @private
 handle_cast(_Msg, S) ->
     {noreply, S}.
+
 
 %% @private
 handle_info({'DOWN', Ref, _, _, _}, S) ->
@@ -241,22 +245,66 @@ handle_info({'DOWN', Ref, _, _, _}, S) ->
     ets:delete(?TAB, Id),
     ets:delete(etorrent_c_pieces, Id),
     {noreply, S#state { monitoring = dict:erase(Ref, S#state.monitoring) }};
+
 handle_info(rate_sparkline_update, S) ->
     for_each_torrent(fun update_sparkline_rate/1),
     erlang:send_after(timer:seconds(60), self(), rate_sparkline_update),
     {noreply, S};
+
 handle_info(_M, S) ->
     {noreply, S}.
+
 
 %% @private
 code_change(_OldVsn, S, _Extra) ->
     {ok, S}.
 
+
 %% @private
 terminate(_Reason, _S) ->
     ok.
 
+
 %% -----------------------------------------------------------------------
+
+
+props_to_record(Id, PL) ->
+
+    % Read optional value. 
+    % If it is undefined then use default value.
+    FO = fun(Key, Def) -> proplists:get_value(Key, PL, Def) end,
+
+    % Read required value.
+    FR = fun(Key) -> 
+            case proplists:get_value(Key, PL) of
+            X when (X =/= undefined) -> X
+            end
+        end,
+
+    L = FR(left),
+
+    % If the `state' is `undefined' or `unknown' then use the default state.
+    State = case FO('state', 'unknown') of
+            'unknown' ->
+                case L of
+                    0 -> seeding;
+                    _ -> leeching
+                end;
+
+            X -> X
+        end,
+
+    #torrent { id = Id,
+               left = L,
+               total = FR('total'),
+               uploaded = FO('uploaded', 0),
+               downloaded = FO('downloaded', 0),
+			   all_time_uploaded = FO('all_time_uploaded', 0),
+			   all_time_downloaded = FO('all_time_downloaded', 0),
+               pieces = FO(pieces, 'unknown'),
+               is_private = FR('is_private'),
+               state = State }.
+
 
 %%--------------------------------------------------------------------
 %% Function: all(Pos) -> Rows
@@ -312,44 +360,78 @@ update_sparkline(NR, L) ->
             [NR | L]
     end.
 
+
 %% Change the state of the torrent with Id, altering it by the "What" part.
 %% Precondition: Torrent exists in the ETS table.
-state_change(_Id, []) ->
-    ok;
-state_change(Id, [What | Rest]) ->
+state_change(Id, List) ->
     %% @todo Be more protective here
     [T] = ets:lookup(?TAB, Id),
-    New = case What of
-              unknown ->
-                  T#torrent{state = unknown};
-              endgame ->
-                  T#torrent{state = endgame};
-              {add_downloaded, Amount} ->
-                  T#torrent{downloaded = T#torrent.downloaded + Amount};
-              {add_upload, Amount} ->
-                  T#torrent{uploaded = T#torrent.uploaded + Amount};
-              {subtract_left, Amount} ->
-                  Left = T#torrent.left - Amount,
-                  case Left of
-                      0 ->
-			  ControlPid = etorrent_torrent_ctl:lookup_server(Id),
-			  etorrent_torrent_ctl:completed(ControlPid),
-                          T#torrent { left = 0, state = seeding,
-				      rate_sparkline = [0.0] };
-                      N when N =< T#torrent.total ->
-                          T#torrent { left = N }
-                  end;
-              {tracker_report, Seeders, Leechers} ->
-                  T#torrent{seeders = Seeders, leechers = Leechers}
-          end,
-    ets:insert(?TAB, New),
-    case {T#torrent.state, New#torrent.state} of
+    NewT = do_state_change(List, T),
+    ets:insert(?TAB, NewT),
+
+    case {T#torrent.state, NewT#torrent.state} of
         {leeching, seeding} ->
             etorrent_event:seeding_torrent(Id),
             ok;
         _ ->
             ok
-    end,
-    state_change(Id, Rest).
+    end.
+
+
+
+
+
+
+do_state_change([unknown | Rem], T) ->
+    do_state_change(Rem, T#torrent{state = unknown});
+
+do_state_change([endgame | Rem], T) ->
+    do_state_change(Rem, T#torrent{state = endgame});
+
+do_state_change([paused | Rem], T) ->
+    do_state_change(Rem, T#torrent{state = paused});
+
+do_state_change([continue | Rem], T) ->
+    NewState = case T#torrent.left of
+            0 -> seeding;
+            _ -> leeching
+        end,
+    do_state_change(Rem, T#torrent{state = NewState});
+
+do_state_change([{add_downloaded, Amount} | Rem], T) ->
+    NewT = T#torrent{downloaded = T#torrent.downloaded + Amount},
+    do_state_change(Rem, NewT);
+
+do_state_change([{add_upload, Amount} | Rem], T) ->
+    NewT = T#torrent{uploaded = T#torrent.uploaded + Amount},
+    do_state_change(Rem, NewT);
+
+do_state_change([{subtract_left, Amount} | Rem], T) ->
+    Left = T#torrent.left - Amount,
+
+    NewT = case Left of
+        0 ->
+            Id = T#torrent.id,
+	        ControlPid = etorrent_torrent_ctl:lookup_server(Id),
+			etorrent_torrent_ctl:completed(ControlPid),
+            T#torrent { 
+                left = 0, 
+                state = seeding,
+                rate_sparkline = [0.0] };
+
+        N when N =< T#torrent.total ->
+           T#torrent { left = N }
+        end,
+
+    do_state_change(Rem, NewT);
+    
+do_state_change([{tracker_report, Seeders, Leechers} | Rem], T) ->
+    NewT = T#torrent{seeders = Seeders, leechers = Leechers},
+    do_state_change(Rem, NewT);
+
+do_state_change([], T) ->
+    T.
+
+
 
 

--- a/src/etorrent_torrent_ctl.erl
+++ b/src/etorrent_torrent_ctl.erl
@@ -17,8 +17,11 @@
 %% API
 -export([start_link/3,
          completed/1,
+         pause_torrent/1,
+         continue_torrent/1,
          check_torrent/1,
-         valid_pieces/1]).
+         valid_pieces/1,
+         switch_mode/2]).
 
 %% gproc registry entries
 -export([register_server/1,
@@ -26,14 +29,56 @@
          await_server/1]).
 
 %% gen_fsm callbacks
--export([init/1, handle_event/3, initializing/2, started/2,
-         handle_sync_event/4, handle_info/3, terminate/3,
+-export([init/1, 
+         handle_event/3, 
+         initializing/2, 
+         started/2, 
+         paused/2,
+         handle_sync_event/4, 
+         handle_info/3, 
+         terminate/3,
          code_change/4]).
 
+%% wish API
+-export([get_permanent_wishes/1,
+         get_wishes/1,
+         set_wishes/2,
+         wish_file/2,
+         wish_piece/2,
+         wish_piece/3,
+         subscribe/3]).
+
+
 -type bcode() :: etorrent_types:bcode().
--type torrentid() :: etorrent_types:torrent_id().
+-type torrent_id() :: etorrent_types:torrent_id().
+-type file_id() :: etorrent_types:file_id().
 -type pieceset() :: etorrent_pieceset:pieceset().
 -type pieceindex() :: etorrent_types:piece_index().
+
+%% If wish is [file_id()], for example, [1,2,3], then create
+%% a mask which has all parts from files 1, 2, 3.
+%% There is some code in `etorrent_io', that tells about how
+%% numbering of files works.
+-type wish() :: [file_id()] | file_id().
+-type wish_list() :: [wish()].
+
+
+-type file_wish()  :: [non_neg_integer()].
+-type piece_wish() :: [non_neg_integer()].
+
+-record(wish, {
+    type :: file | piece,
+    value :: file_wish() | piece_wish(),
+    is_completed = false :: boolean(),
+    %% Transient wishes are 
+    %% * __small__  
+    %% * __hidden__ for fast_resume module
+    %% * always on top of the set of wishes.
+    is_transient = false :: boolean(),
+    subscribed = [] :: [pid()],
+    pieceset :: pieceset()
+}).
+
 -record(state, {
     id          :: integer() ,
     torrent     :: bcode(),   % Parsed torrent file
@@ -45,19 +90,23 @@
     tracker_pid :: pid(),
     progress    :: pid(),
     pending     :: pid(),
-    endgame     :: pid()}).
+    wishes = [] :: [#wish{}],
+    interval    :: timer:interval(),
+    mode = progress 
+                :: 'progress' | 'endgame' | atom()
+    }).
 
 
 
--spec register_server(torrentid()) -> true.
+-spec register_server(torrent_id()) -> true.
 register_server(TorrentID) ->
     etorrent_utils:register(server_name(TorrentID)).
 
--spec lookup_server(torrentid()) -> pid().
+-spec lookup_server(torrent_id()) -> pid().
 lookup_server(TorrentID) ->
     etorrent_utils:lookup(server_name(TorrentID)).
 
--spec await_server(torrentid()) -> pid().
+-spec await_server(torrent_id()) -> pid().
 await_server(TorrentID) ->
     etorrent_utils:await(server_name(TorrentID)).
 
@@ -82,12 +131,254 @@ check_torrent(Pid) ->
 completed(Pid) ->
     gen_fsm:send_event(Pid, completed).
 
+%% @doc Set the torrent on pause
+%% @end
+-spec pause_torrent(pid()) -> ok.
+pause_torrent(Pid) ->
+    gen_fsm:send_event(Pid, pause).
+
+%% @doc Continue leaching or seeding 
+%% @end
+-spec continue_torrent(pid()) -> ok.
+continue_torrent(Pid) ->
+    gen_fsm:send_event(Pid, continue).
+
 %% @doc Get the set of valid pieces for this torrent
 %% @end
 -spec valid_pieces(pid()) -> {ok, pieceset()}.
 valid_pieces(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, valid_pieces).
 
+
+switch_mode(Pid, Mode) ->
+    gen_fsm:send_all_state_event(Pid, {switch_mode, Mode}).
+
+
+
+
+%% =====================\/=== Wish API ===\/===========================
+
+%% @doc Update wishlist.
+%%      This function returns __minimized__ version of wishlist.
+-spec set_wishes(torrent_id(), wish_list()) -> {ok, wish_list()}.
+
+set_wishes(TorrentID, Wishes) ->
+    {ok, FilteredWishes} = set_record_wishes(TorrentID, to_records(Wishes)),
+    {ok, to_proplists(FilteredWishes)}.
+
+
+-spec get_wishes(torrent_id()) -> {ok, wish_list()}.
+
+get_wishes(TorrentID) ->
+    {ok, Wishes} = get_record_wishes(TorrentID),
+    {ok, to_proplists(Wishes)}.
+
+
+get_permanent_wishes(TorrentID) ->
+    {ok, Wishes} = get_record_wishes(TorrentID),
+    {ok, to_proplists([X || X <- Wishes, not X#wish.is_transient])}.
+
+
+%% @doc Add a file at top of wishlist.
+%%      Added file will have highest priority inside this torrent.
+-spec wish_file(torrent_id(), wish()) -> {ok, wish_list()}.
+
+wish_file(TorrentID, [FileID]) when is_integer(FileID) ->
+    wish_file(TorrentID, FileID);
+
+wish_file(TorrentID, FileID) ->
+    {ok, OldWishes} = get_record_wishes(TorrentID),
+    Wish = #wish {
+      type = file,
+      value = FileID
+    },
+    NewWishes = [ Wish | OldWishes ],
+    {ok, FilteredWishes} = set_record_wishes(TorrentID, NewWishes),
+    {ok, to_proplists(FilteredWishes)}.
+
+
+wish_piece(TorrentID, PieceID) ->
+    wish_piece(TorrentID, PieceID, false).
+
+
+wish_piece(TorrentID, PieceID, IsTemporary) ->
+    {ok, OldWishes} = get_record_wishes(TorrentID),
+    Wish = #wish {
+      type = piece,
+      value = PieceID,
+      is_transient = IsTemporary
+    },
+    NewWishes = [ Wish | OldWishes ],
+    {ok, FilteredWishes} = set_record_wishes(TorrentID, NewWishes),
+    {ok, to_proplists(FilteredWishes)}.
+
+
+%% @doc If the wish {Type, Value} will be completed,
+%%      caller will receive {completed, Ref}.
+%%      Use wish_file of wish_piece functions before calling this function.
+subscribe(TorrentID, Type, Value) ->
+    CtlSrv = lookup_server(TorrentID),
+    gen_fsm:sync_send_all_state_event(CtlSrv, {subscribe, Type, Value}).
+
+  
+%% @doc Send information to the subscribed processes.
+%% @private
+alert_subscribed(Clients) ->
+    [Pid ! {completed, Ref} || {Pid, Ref} <- Clients].
+
+
+%% @private
+get_record_wishes(TorrentID) ->
+    CtlSrv = lookup_server(TorrentID),
+    gen_fsm:sync_send_all_state_event(CtlSrv, get_wishes).
+
+
+%% @private
+set_record_wishes(TorrentID, Wishes) ->
+    CtlSrv = lookup_server(TorrentID),
+    gen_fsm:sync_send_all_state_event(CtlSrv, {set_wishes, Wishes}).
+
+
+to_proplists(Records) ->
+    [[{type, Type}
+     ,{value, Value}
+     ,{is_completed, IsCompleted}
+     ,{is_transient, IsTransient}
+     ] || #wish{ type = Type, 
+                value = Value, 
+         is_completed = IsCompleted,
+         is_transient = IsTransient } <- Records].
+
+
+to_records(Props) ->
+    [#wish{type = proplists:get_value(type, X), 
+          value = proplists:get_value(value, X),
+   is_transient = proplists:get_value(is_transient, X, false)
+   } || X <- Props, is_list(X)].
+
+
+to_pieceset(TorrentID, #wish{ type = file, value = FileIds }) ->
+    etorrent_info:get_mask(TorrentID, FileIds);
+
+to_pieceset(TorrentID, #wish{ type = piece, value = List }) ->
+    Pieceset = etorrent_info:get_mask(TorrentID, 0),
+    Size = etorrent_pieceset:capacity(Pieceset),
+    etorrent_pieceset:from_list(List, Size).
+
+
+%% @private
+validate_wishes(TorrentID, NewWishes, OldWishes, ValidPieces) ->
+    val_(TorrentID, NewWishes, OldWishes, ValidPieces, []).
+    
+
+%% @doc Fix incomplete wishes.
+%% @private
+val_(Tid, [NewH|NewT], Old, Valid, Acc) ->
+    case search_wish(NewH, Acc) of
+    %% Signature is already used
+    #wish{} -> 
+        val_(Tid, NewT, Old, Valid, Acc);
+
+    false ->
+        Rec = case search_wish(NewH, Old) of
+                %% New wish
+                false ->
+                    WishSet = to_pieceset(Tid, NewH),
+                    Left = etorrent_pieceset:difference(WishSet, Valid),
+                    IsCompleted = etorrent_pieceset:is_empty(Left),
+                    NewH#wish {
+                      is_completed = IsCompleted,
+                      pieceset = WishSet
+                    };
+
+                RecI -> 
+                    %% If old wish is transient and new is permanent, then set as permanent.
+                    RecI#wish{is_transient=(NewH#wish.is_transient 
+                                        and RecI#wish.is_transient)}
+            end,
+        val_(Tid, NewT, Old, Valid, [Rec|Acc])
+    end;
+
+val_(_Tid, [], _Old, _Valid, Acc) ->
+    %% Transient wishes are always on top of a query.
+    lists:keysort(#wish.is_transient, lists:reverse(Acc)).
+    
+
+%% @doc Check status of wishes.
+%%      This function will be called periditionally.
+check_completed(RecList, Valid) ->
+    chk_(RecList, Valid, [], []).
+
+
+chk_([H=#wish{ is_completed = true }|T], Valid, RecAcc, Ready) ->
+   chk_(T, Valid, [H|RecAcc], Ready);
+
+chk_([H|T], Valid, RecAcc, Ready) ->
+    #wish{ is_completed = false, pieceset = WishSet, is_transient = IsTransient } = H,
+ 
+    Left = etorrent_pieceset:difference(WishSet, Valid),
+    IsCompleted = etorrent_pieceset:is_empty(Left),
+    Rec = H#wish{ is_completed = IsCompleted },
+    case {IsCompleted, IsTransient} of 
+        %% Subscribed clients will be alerted. 
+        %% Clear subscriptions.
+        {true, true} -> 
+            chk_(T, Valid, [Rec#wish{ subscribed=[] }|RecAcc], [Rec|Ready]);
+        %% Subscribed clients will be alerted. 
+        %% Delete element.
+        {true, false} -> 
+            chk_(T, Valid, RecAcc, [Rec|Ready]);
+        {false, _} -> 
+            chk_(T, Valid, [Rec|RecAcc], Ready)
+    end;
+
+chk_([], _Valid, RecAcc, Ready) ->
+    {lists:reverse(RecAcc), lists:reverse(Ready)}.
+
+    
+%% @doc Save pid() as subscriber
+%%      Client is {pid(), ref()}
+%% @private
+add_subscribtion(RecList, Type, Value, Client) ->
+    sub_(RecList, Type, Value, Client, []).
+
+
+sub_([#wish{ is_completed = true, type = Type, value = Value }|_]=T, 
+        Type, Value, _Client, Acc) ->
+    {completed, lists:reverse(Acc, T)};
+
+sub_([H=#wish{ is_completed = false, type = Type, value = Value, 
+        subscribed = S }|T], 
+        Type, Value, Client, Acc) ->
+
+    NewAcc = [H#wish { subscribed = [Client|S]} | Acc],
+    {subscribed, lists:reverse(NewAcc, T)};
+
+sub_([H|T], Type, Value, Client, Acc) ->
+    sub_(T, Type, Value, Client, [H|Acc]);
+
+sub_([], _Type, _Value, _Client, Acc) ->
+    {completed, lists:reverse(Acc)}.
+
+
+%% @doc Search the element with the same signature in the array.
+%% @private
+search_wish(#wish{ type = Type, value = Value },
+       [H = #wish{ type = Type, value = Value } | _T]) ->
+    H;
+
+search_wish(El, [_H|T]) ->
+    search_wish(El, T);
+
+search_wish(_El, []) ->
+    false.
+
+
+
+
+
+%% =====================/\=== Wish API ===/\===========================
+    
 
 %% ====================================================================
 
@@ -107,74 +398,18 @@ init([Parent, Id, {Torrent, TorrentFile, TorrentIH}, PeerId]) ->
     {ok, initializing, InitState, 0}.
 
 %% @private
-%% @todo Split and simplify this monster function
-initializing(timeout, #state{id=Id, torrent=Torrent, hashes=Hashes} = S0) ->
+initializing(timeout, #state{id=Id} = S0) ->
     Pending  = etorrent_pending:await_server(Id),
-    Endgame  = etorrent_endgame:await_server(Id),
     S = S0#state{
-        pending=Pending,
-        endgame=Endgame},
+        pending=Pending},
 
     case etorrent_table:acquire_check_token(Id) of
         false ->
             {next_state, initializing, S, ?CHECK_WAIT_TIME};
         true ->
-            %% @todo: Try to coalesce some of these operations together.
-
-            %% Read the torrent, check its contents for what we are missing
-            etorrent_table:statechange_torrent(Id, checking),
-            etorrent_event:checking_torrent(Id),
-            ValidPieces = read_and_check_torrent(Id, Hashes),
-            Left = calculate_amount_left(Id, ValidPieces, Torrent),
-            NumberOfPieces = etorrent_pieceset:capacity(ValidPieces),
-            {AU, AD} =
-                case etorrent_fast_resume:query_state(S#state.id) of
-                    unknown -> {0,0};
-                    {value, PL} ->
-                        {proplists:get_value(uploaded, PL),
-                         proplists:get_value(downloaded, PL)}
-                end,
-
-            %% Add a torrent entry for this torrent.
-            ok = etorrent_torrent:new(
-                   Id,
-                   {{uploaded, 0},
-                    {downloaded, 0},
-                    {all_time_uploaded, AU},
-                    {all_time_downloaded, AD},
-                    {left, Left},
-                    {total, etorrent_metainfo:get_length(Torrent)},
-                    {is_private, etorrent_metainfo:is_private(Torrent)},
-                    {pieces, ValidPieces}},
-                   NumberOfPieces),
-
-            %% Start the progress manager
-            {ok, ProgressPid} =
-                etorrent_torrent_sup:start_progress(
-                  S#state.parent_pid,
-                  Id,
-                  Torrent,
-                  ValidPieces),
-
-            %% Update the tracking map. This torrent has been started.
-            %% Altering this state marks the point where we will accept
-            %% Foreign connections on the torrent as well.
-            etorrent_table:statechange_torrent(Id, started),
-            etorrent_event:started_torrent(Id),
-
-            %% Start the tracker
-            {ok, TrackerPid} =
-                etorrent_torrent_sup:start_child_tracker(
-                  S#state.parent_pid,
-                  etorrent_metainfo:get_url(Torrent),
-                  S#state.info_hash,
-                  S#state.peer_id,
-                  Id),
-
-            NewState = S#state{tracker_pid=TrackerPid, valid=ValidPieces,
-                               progress = ProgressPid },
-            {next_state, started, NewState}
+            do_registration(S)
     end.
+
 
 %% @private
 started(check_torrent, State) ->
@@ -188,27 +423,141 @@ started(check_torrent, State) ->
 started(completed, #state{id=Id, tracker_pid=TrackerPid} = S) ->
     etorrent_event:completed_torrent(Id),
     etorrent_tracker_communication:completed(TrackerPid),
+    {next_state, started, S};
+
+started(pause, #state{id=Id, interval=I} = SO) ->
+%   etorrent_event:paused_torrent(Id),
+    
+    etorrent_table:statechange_torrent(Id, stopped),
+    etorrent_event:stopped_torrent(Id),
+    ok = etorrent_torrent:statechange(Id, [paused]),
+    ok = etorrent_torrent_sup:pause(SO#state.parent_pid),
+    {ok, cancel} = timer:cancel(I),
+
+    S = SO#state{ tracker_pid = undefined, 
+                     progress = undefined, 
+                     interval = undefined },
+    {next_state, paused, S};
+
+started(continue, S) ->
     {next_state, started, S}.
 
+
+
+paused(continue, #state{id=Id} = S) ->
+    Ret = do_start(S),
+    ok = etorrent_torrent:statechange(Id, [continue]),
+    Ret;
+paused(pause, S) ->
+    {next_state, paused, S}.
+
+
+
 %% @private
+handle_event({switch_mode, Mode}, SN, S=#state{mode=Mode}) ->
+    {next_state, SN, S};
+
+handle_event({switch_mode, NewMode}, SN, S=#state{mode=OldMode}) ->
+    lager:info("Switch mode: ~p => ~p ~n", [OldMode, NewMode]),
+    #state{mode=OldMode, parent_pid=Sup, id=TorrentID,
+        valid=ValidPieceSet} = S,
+
+    etorrent_torrent_sup:stop_assignor(Sup),
+
+    {ok, Assignor} = 
+        case NewMode of
+        'progress' ->
+            #state{torrent=Torrent, 
+                    wishes=Wishes} = S,
+            Masks = wishes_to_masks(Wishes),
+
+            %% Start the progress manager
+            etorrent_torrent_sup:start_progress(
+              Sup,
+              TorrentID,
+              Torrent,
+              ValidPieceSet,
+              Masks);
+
+        'endgame' ->
+            etorrent_torrent_sup:start_endgame(
+              Sup,
+              TorrentID)
+        end,
+        
+    
+    Peers = etorrent_peer_control:lookup_peers(TorrentID),
+    [etorrent_download:switch_assignor(Peer, Assignor) || Peer <- Peers],
+
+    {next_state, SN, S#state{mode=NewMode}};
+
 handle_event(Msg, SN, S) ->
-    io:format("Problem: ~p~n", [Msg]),
+    lager:error("Problem: ~p~n", [Msg]),
     {next_state, SN, S}.
+
+
 
 %% @private
 handle_sync_event(valid_pieces, _, StateName, State) ->
     #state{valid=Valid} = State,
-    {reply, {ok, Valid}, StateName, State}.
+    {reply, {ok, Valid}, StateName, State};
 
-%% @private
+
+
+handle_sync_event({subscribe, Type, Value}, {_Pid, Ref} = Client, SN, SD) ->
+    OldWishes = SD#state.wishes,
+
+    case add_subscribtion(OldWishes, Type, Value, Client) of
+        {subscribed, NewWishes} ->
+            {reply, {subscribed, Ref}, SN, SD#state{wishes=NewWishes}};
+
+        {completed, _NewWishes} ->
+            {reply, completed, SN, SD}
+    end;
+
+handle_sync_event(get_wishes, _From, SN, SD) ->
+    Wishes = SD#state.wishes,
+    {reply, {ok, Wishes}, SN, SD};
+
+handle_sync_event({set_wishes, NewWishes}, _From, SN, 
+    SD=#state{id=Id, wishes=OldWishes, valid=ValidPieces}) ->
+    Wishes = validate_wishes(Id, NewWishes, OldWishes, ValidPieces),
+    
+    case SN of
+        paused -> skip;
+        _ -> 
+            Masks = wishes_to_masks(Wishes),
+            %% Tell to the progress manager about new list of wanted pieces
+            etorrent_progress:set_wishes(Id, Masks)
+    end,
+
+    {reply, {ok, Wishes}, SN, SD#state{wishes=Wishes}}.
+
+
+wishes_to_masks(Wishes) ->
+    [X#wish.pieceset || X <- Wishes, not X#wish.is_completed ].
+
+
 %% Tell the controller we have stored an index for this torrent file
+%% @private
+handle_info(check_completed, SN, SD=#state{valid = Valid, wishes = Wishes}) ->
+    {NewWishes, CompletedWishes} = check_completed(Wishes, Valid),
+    [alert_subscribed(Clients) 
+        || #wish{subscribed = Clients} 
+        <- CompletedWishes],
+    {next_state, SN, SD#state{wishes = NewWishes}};
+
 handle_info({piece, {stored, Index}}, started, State) ->
-    #state{id=TorrentID, hashes=Hashes, progress=Progress, valid=ValidPieces} = State,
+    #state{id=TorrentID, 
+        hashes=Hashes, 
+        progress=Progress, 
+        valid=ValidPieces} = State,
     Piecehash = fetch_hash(Index, Hashes),
     case etorrent_io:check_piece(TorrentID, Index, Piecehash) of
         {ok, PieceSize} ->
             Peers = etorrent_peer_control:lookup_peers(TorrentID),
-            ok = etorrent_torrent:statechange(TorrentID, [{subtract_left, PieceSize}]),
+            ok = etorrent_torrent:statechange(TorrentID, 
+                [{subtract_left, PieceSize}]),
             ok = etorrent_piecestate:valid(Index, Peers),
             ok = etorrent_piecestate:valid(Index, Progress),
             NewValidState = etorrent_pieceset:insert(Index, ValidPieces),
@@ -219,6 +568,7 @@ handle_info({piece, {stored, Index}}, started, State) ->
             ok = etorrent_piecestate:unassigned(Index, Peers),
             {next_state, started, State}
     end;
+
 handle_info(Info, StateName, State) ->
     lager:error("Unknown handle_info event: ~p", [Info]),
     {next_state, StateName, State}.
@@ -231,6 +581,107 @@ terminate(_Reason, _StateName, _S) ->
 %% @private
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
+
+
+
+
+
+
+%% --------------------------------------------------------------------
+
+do_registration(S=#state{id=Id, torrent=Torrent, hashes=Hashes}) ->
+    %% @todo: Try to coalesce some of these operations together.
+
+    %% Read the torrent, check its contents for what we are missing
+    FastResumePL = etorrent_fast_resume:query_state(Id),
+
+    etorrent_table:statechange_torrent(Id, checking),
+    etorrent_event:checking_torrent(Id),
+    ValidPieces = read_and_check_torrent(Id, Hashes, FastResumePL),
+    Left = calculate_amount_left(Id, ValidPieces, Torrent),
+    NumberOfPieces = etorrent_pieceset:capacity(ValidPieces),
+    NumberOfValidPieces = etorrent_pieceset:size(ValidPieces),
+    NumberOfMissingPieces = NumberOfPieces - NumberOfValidPieces,
+
+    AU = proplists:get_value(uploaded, FastResumePL, 0),
+    AD = proplists:get_value(downloaded, FastResumePL, 0),
+    TState = proplists:get_value(state, FastResumePL, unknown),
+    Wishes = proplists:get_value(wishes, FastResumePL, []),
+
+    %% Add a torrent entry for this torrent.
+    %% @todo Minimize calculation in `etorrent_torrent' module.
+    ok = etorrent_torrent:new(
+           Id,
+           [{uploaded, 0},
+            {downloaded, 0},
+            {all_time_uploaded, AU},
+            {all_time_downloaded, AD},
+            {left, Left},
+            {total, etorrent_metainfo:get_length(Torrent)},
+            {is_private, etorrent_metainfo:is_private(Torrent)},
+            {pieces, NumberOfValidPieces},
+            {missing, NumberOfMissingPieces},
+            {state, TState}]),
+
+    WishRecordSet = try
+        validate_wishes(Id, to_records(Wishes), [], ValidPieces)
+        catch error:Reason ->
+        error_logger:error_msg("Wishes from fast_resume "
+            "module are invalidate~n ~w", [Reason]),
+        []
+    end,
+    NewState = S#state{ valid=ValidPieces, wishes = WishRecordSet },
+
+    case TState of
+        paused ->
+            etorrent_table:statechange_torrent(Id, stopped),
+            etorrent_event:stopped_torrent(Id),
+            {next_state, paused, NewState};
+        _ -> 
+        do_start(NewState)
+    end.
+
+
+do_start(S=#state{id=Id, torrent=Torrent, valid=ValidPieces, wishes=Wishes}) ->
+    Masks = wishes_to_masks(Wishes),
+
+    %% Start the progress manager
+    {ok, ProgressPid} =
+        etorrent_torrent_sup:start_progress(
+          S#state.parent_pid,
+          Id,
+          Torrent,
+          ValidPieces,
+          Masks),
+
+    %% Update the tracking map. This torrent has been started.
+    %% Altering this state marks the point where we will accept
+    %% Foreign connections on the torrent as well.
+    etorrent_table:statechange_torrent(Id, started),
+    etorrent_event:started_torrent(Id),
+
+    %% Start the tracker
+    {ok, TrackerPid} =
+        etorrent_torrent_sup:start_child_tracker(
+          S#state.parent_pid,
+          etorrent_metainfo:get_url(Torrent),
+          S#state.info_hash,
+          S#state.peer_id,
+          Id),
+
+    etorrent_torrent_sup:start_peer_sup(S#state.parent_pid, Id),
+
+    {ok, Timer} = timer:send_interval(10000, check_completed),
+
+    NewState = S#state{tracker_pid = TrackerPid,
+                          progress = ProgressPid,
+                          interval = Timer },
+
+    {next_state, started, NewState}.
+
+
+%% @todo run this when starting:
+%% etorrent_event:seeding_torrent(Id),
 
 %% --------------------------------------------------------------------
 
@@ -252,37 +703,53 @@ calculate_amount_left(TorrentID, Valid, Torrent) ->
 %   system knows what is going on, use that information. Otherwise, form all possible
 %   pieces, but filter them through a correctness checker.</p>
 % @end
--spec read_and_check_torrent(integer(), binary()) -> pieceset().
-read_and_check_torrent(TorrentID, Hashes) ->
+-spec read_and_check_torrent(integer(), binary(), [{atom(), term()}]) -> pieceset().
+read_and_check_torrent(TorrentID, Hashes, PL) ->
     ok = etorrent_io:allocate(TorrentID),
     Numpieces = num_hashes(Hashes),
-    %% Check the contents of the torrent, updates the state of the piecemap
-    case etorrent_fast_resume:query_state(TorrentID) of
-        {value, PL} ->
-            case proplists:get_value(state, PL) of
-                seeding ->
-                    etorrent_pieceset:full(Numpieces);
-                {bitfield, Bin} ->
-                    etorrent_pieceset:from_binary(Bin, Numpieces)
-            end;
-        unknown ->
+    Stage = to_stage(PL),
+    case Stage of
+        unknown -> 
             All  = etorrent_pieceset:full(Numpieces),
-            filter_pieces(TorrentID, All, Hashes)
+            filter_pieces(TorrentID, All, Hashes);
+        completed -> 
+            etorrent_pieceset:full(Numpieces);
+        incompleted ->
+            Bin = proplists:get_value(bitfield, PL),
+            etorrent_pieceset:from_binary(Bin, Numpieces)
     end.
+    
+    
+%% @doc This simple function transforms the stored state of the torrent 
+%%      to the stage of the downloading process. PL is stored in 
+%%      the `etorrent_fast_resume' module.
+-spec to_stage([{atom(), term()}]) -> atom().
+to_stage([]) -> unknown;
+to_stage(PL) -> 
+    case proplists:get_value(bitfield, PL) of
+    undefined ->
+        completed;
+    _ ->
+        incompleted
+    end.
+        
+
 
 
 % @doc Filter a pieceset() w.r.t data on disk.
 % <p>Given a set of pieces to check, `ToCheck', check each piece in there for validity.
 %  return a pieceset() where all invalid pieces have been filtered out.</p>
 % @end
--spec filter_pieces(torrentid(), pieceset(), binary()) -> pieceset().
+-spec filter_pieces(torrent_id(), pieceset(), binary()) -> pieceset().
 filter_pieces(TorrentID, ToCheck, Hashes) ->
     Indexes = etorrent_pieceset:to_list(ToCheck),
     ValidIndexes = [I || I <- Indexes, is_valid_piece(TorrentID, I, Hashes)],
     Numpieces = etorrent_pieceset:capacity(ToCheck),
     etorrent_pieceset:from_list(ValidIndexes, Numpieces).
 
--spec is_valid_piece(torrentid(), pieceindex(), binary()) -> boolean().
+
+-spec is_valid_piece(torrent_id(), pieceindex(), binary()) -> boolean().
+
 is_valid_piece(TorrentID, Index, Hashes) ->
     Hash = fetch_hash(Index, Hashes),
     case etorrent_io:check_piece(TorrentID, Index, Hash) of
@@ -295,10 +762,12 @@ is_valid_piece(TorrentID, Index, Hashes) ->
 hashes_to_binary(Hashes) ->
     hashes_to_binary(Hashes, <<>>).
 
+
 hashes_to_binary([], Acc) ->
     Acc;
 hashes_to_binary([H=(<<_:160>>)|T], Acc) ->
     hashes_to_binary(T, <<Acc/binary, H/binary>>).
+
 
 fetch_hash(Piece, Hashes) ->
     Offset = 20 * Piece,
@@ -306,6 +775,7 @@ fetch_hash(Piece, Hashes) ->
         <<_:Offset/binary, Hash:20/binary, _/binary>> -> Hash;
         _ -> erlang:error(badarg)
     end.
+
 
 num_hashes(Hashes) ->
     byte_size(Hashes) div 20.
@@ -323,5 +793,6 @@ hashes_to_binary_test_() ->
      ?_assertEqual(3, num_hashes(Bin)),
      ?_assertError(badarg, fetch_hash(-1, Bin)),
      ?_assertError(badarg, fetch_hash(3, Bin))].
+
 
 -endif.

--- a/src/etorrent_torrent_sup.erl
+++ b/src/etorrent_torrent_sup.erl
@@ -10,7 +10,11 @@
 -export([start_link/3,
 
          start_child_tracker/5,
-         start_progress/4]).
+         start_progress/5,
+         start_endgame/2,
+         start_peer_sup/2,
+         stop_assignor/1,
+         pause/1]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -19,7 +23,6 @@
 -type tier() :: etorrent_types:tier().
 
 
--define(DEFAULT_CHUNK_SIZE, 16#4000). % TODO - get this value from a configuration file
 %% =======================================================================
 
 %% @doc Start up the supervisor
@@ -48,28 +51,52 @@ start_child_tracker(Pid, UrlTiers, InfoHash, Local_Peer_Id, TorrentId) ->
     Tracker = {tracker_communication,
                {etorrent_tracker_communication, start_link,
                 [self(), UrlTiers, InfoHash, Local_Peer_Id, TorrentId]},
-               permanent, 15000, worker, [etorrent_tracker_communication]},
+               transient, 15000, worker, [etorrent_tracker_communication]},
     supervisor:start_child(Pid, Tracker).
 
 -spec start_progress(pid(), etorrent_types:torrent_id(),
                             etorrent_types:bcode(),
-                            etorrent_pieceset:pieceset()) ->
+                            etorrent_pieceset:pieceset(),
+                            [etorrent_pieceset:pieceset()]) ->
                             {ok, pid()} | {ok, pid(), term()} | {error, term()}.
-start_progress(Pid, TorrentID, Torrent, ValidPieces) ->
-    Spec = progress_spec(TorrentID, Torrent, ValidPieces),
+start_progress(Pid, TorrentID, Torrent, ValidPieces, Wishes) ->
+    Spec = progress_spec(TorrentID, Torrent, ValidPieces, Wishes),
     supervisor:start_child(Pid, Spec).
+
+start_endgame(Pid, TorrentID) ->
+    Spec = endgame_spec(TorrentID),
+    supervisor:start_child(Pid, Spec).
+
+start_peer_sup(Pid, TorrentID) ->
+    Spec = peer_pool_spec(TorrentID),
+    supervisor:start_child(Pid, Spec).
+
+pause(Pid) ->
+    ok = supervisor:terminate_child(Pid, peer_pool_sup),
+    ok = supervisor:delete_child(Pid, peer_pool_sup),
+    ok = supervisor:terminate_child(Pid, tracker_communication),
+    ok = supervisor:delete_child(Pid, tracker_communication),
+    ok = supervisor:terminate_child(Pid, chunk_mgr),
+    ok = supervisor:delete_child(Pid, chunk_mgr),
+    ok.
+
+
+stop_assignor(Pid) ->
+    ok = supervisor:terminate_child(Pid, chunk_mgr),
+    ok = supervisor:delete_child(Pid, chunk_mgr).
+
+
     
 %% ====================================================================
 
 %% @private
 init([{Torrent, TorrentPath, TorrentIH}, PeerID, TorrentID]) ->
     Children = [
+        info_spec(TorrentID, Torrent),
+        io_sup_spec(TorrentID, Torrent),
         pending_spec(TorrentID),
         scarcity_manager_spec(TorrentID, Torrent),
-        torrent_control_spec(TorrentID, Torrent, TorrentPath, TorrentIH, PeerID),
-        endgame_spec(TorrentID),
-        io_sup_spec(TorrentID, Torrent),
-        peer_pool_spec(TorrentID)],
+        torrent_control_spec(TorrentID, Torrent, TorrentPath, TorrentIH, PeerID)],
     {ok, {{one_for_all, 1, 60}, Children}}.
 
 pending_spec(TorrentID) ->
@@ -83,18 +110,18 @@ scarcity_manager_spec(TorrentID, Torrent) ->
         {etorrent_scarcity, start_link, [TorrentID, Numpieces]},
         permanent, 5000, worker, [etorrent_scarcity]}.
 
-progress_spec(TorrentID, Torrent, ValidPieces) ->
+progress_spec(TorrentID, Torrent, ValidPieces, Wishes) ->
     PieceSizes  = etorrent_io:piece_sizes(Torrent), 
-    ChunkSize   = ?DEFAULT_CHUNK_SIZE,
-    Args = [TorrentID, ChunkSize, ValidPieces, PieceSizes, lookup],
+    ChunkSize   = etorrent_info:chunk_size(TorrentID),
+    Args = [TorrentID, ChunkSize, ValidPieces, PieceSizes, lookup, Wishes],
     {chunk_mgr,
         {etorrent_progress, start_link, Args},
-        permanent, 20000, worker, [etorrent_progress]}.
+        transient, 20000, worker, [etorrent_progress]}.
 
 endgame_spec(TorrentID) ->
-    {endgame,
+    {chunk_mgr,
         {etorrent_endgame, start_link, [TorrentID]},
-        permanent, 5000, worker, [etorrent_endgame]}.
+        transient, 5000, worker, [etorrent_endgame]}.
 
 torrent_control_spec(TorrentID, Torrent, TorrentFile, TorrentIH, PeerID) ->
     {control,
@@ -106,6 +133,11 @@ io_sup_spec(TorrentID, Torrent) ->
     {fs_pool,
         {etorrent_io_sup, start_link, [TorrentID, Torrent]},
         transient, 5000, supervisor, [etorrent_io_sup]}.
+
+info_spec(TorrentID, Torrent) ->
+    {info,
+        {etorrent_info, start_link, [TorrentID, Torrent]},
+        transient, 5000, worker, [etorrent_info]}.
 
 peer_pool_spec(TorrentID) ->
     {peer_pool_sup,

--- a/src/etorrent_tracker_communication.erl
+++ b/src/etorrent_tracker_communication.erl
@@ -66,6 +66,8 @@ start_link(ControlPid, UrlTiers, InfoHash, PeerId, TorrentId)
 completed(Pid) ->
     gen_server:cast(Pid, completed).
 
+
+
 %%====================================================================
 
 %% @private
@@ -89,10 +91,13 @@ init([ControlPid, UrlTiers, InfoHash, PeerId, TorrentId]) ->
 
                 queued_message = started}}.
 
+
 %% @private
 handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
+
+
 
 %% @private
 handle_cast(completed, S) ->

--- a/src/etorrent_types.erl
+++ b/src/etorrent_types.erl
@@ -24,6 +24,7 @@
               tier/0,
               token/0,
               torrent_id/0,
+              file_id/0,
               tracker_event/0,
               trackerinfo/0,
               transaction/0,
@@ -40,6 +41,7 @@
 -type bcode() ::
     integer() | binary() | [bcode(),...] | [{binary(), bcode()},...] | {}.
 -type torrent_id() :: integer().
+-type file_id() :: non_neg_integer().
 -type file_path() :: string().
 
 % Type returned by the From tag in gen_*:handle_call

--- a/src/etorrent_upnp_net.erl
+++ b/src/etorrent_upnp_net.erl
@@ -240,7 +240,8 @@ handle_cast({discover, ST}, #state{ssdp_sock = Sock} = S) ->
                 "MX: 1\r\n"
                 "ST: '">>, list_to_binary(ST), <<"'\r\n"
                 "\r\n">>],
-    ok = gen_udp:send(Sock, ?SSDP_ADDR, ?SSDP_PORT, iolist_to_binary(MSearch)),
+    %% If the connection is not ready, then we will have an error.
+    gen_udp:send(Sock, ?SSDP_ADDR, ?SSDP_PORT, iolist_to_binary(MSearch)),
     {noreply, S};
 handle_cast({description, Device}, State) ->
     {ok, Devices, Services} = recv_desc(Device),

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+cd `dirname $0`
+
+# NOTE: mustache templates need \ because they are not awesome.
+exec erl -pa $PWD/ebin edit $PWD/deps/*/ebin \
+    -boot start_sasl \
+    -sname etorrent \
+    -s etorrent_app \
+    -config ~/.config/etorrent
+


### PR DESCRIPTION
Changelog
- `switch_assignor` (`switch_mode`) allows using of not only  `etorrent_progress` and `etorrent_endgame`, but any other `gen_server`, that realizes the interface.
- Wish support - you can change the files' downloading order inside the torrent. 
- Optimizations for torrents with a lot of files. But it is still slow.
  The idea for the future is running a gen_server for requested (active) files only, not for all files. 
- Pause / start torrents.
- webadmin uses qooxdoo (on port 1080).
