### PR TITLE
Change URL of the cascadae dependence

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,5 +27,5 @@
        {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}},
        {cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}},
        {rlimit, ".*", {git, "git://github.com/jlouis/rlimit.git", "master"}},
-       {cascadae, ".*", {git, "git://github.com/freeakk/cascadae.git", "master"}}
+       {cascadae, ".*", {git, "git://github.com//cytozoon/cascadae.git", "master"}}
        ]}.

--- a/src/etorrent_info.erl
+++ b/src/etorrent_info.erl
@@ -1,4 +1,4 @@
-% @author Uvarov Michail <freeakk@gmail.com>
+% @author Uvarov Michail <cytozoon@gmail.com>
 
 -module(etorrent_info).
 -behaviour(gen_server).


### PR DESCRIPTION
I moved the web UI repository to the new address. 
