### PR TITLE
 Servname not supported for ai_socktype

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
        {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}},
        {cowboy, ".*", {git, "git://github.com/extend/cowboy.git", {tag, "0.8.0"}}},
        %% For mochiweb_utils
-       {mochiweb, ".*", {git, "git://github.com:mochi/mochiweb.git", "master"}},
+       {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", "master"}},
        {rlimit, ".*", {git, "git://github.com/arcusfelis/rlimit.git", "master"}},
        {azdht, ".*", {git, "git://github.com/arcusfelis/azdht.git", "master"}},
        {mdns, ".*", {git, "git://github.com/arcusfelis/mdns.git", "master"}},


### PR DESCRIPTION
I was getting

ERROR: git clone -n git://github.com:mochi/mochiweb.git mochiweb failed with error: 128 and output:
fatal: unable to connect to github.com:
github.com: Servname not supported for ai_socktype

when I tried to "Make deps", changing git://github.com:mochi/mochiweb.git to git://github.com/mochi/mochiweb.git fix this issue.
