### PR TITLE
identify_url_type: remove inet:getaddr and add EUnit tests

### DIFF
--- a/src/etorrent_tracker_communication.erl
+++ b/src/etorrent_tracker_communication.erl
@@ -48,7 +48,7 @@
 -export([ifaddrs/0]).
 
 -ifdef(TEST).
--export([first_tracker_id/1]).
+-export([first_tracker_id/1, identify_url_type/1]).
 -endif.
 
 -type tier() :: [{integer(), binary()}].
@@ -231,18 +231,19 @@ contact_tracker_tier([{TrackerID, Url} = Cur | Next], Event, S, Acc) ->
     end.
 
 identify_url_type(Url) ->
-	case etorrent_http_uri:parse(Url) of
-	  {S1, _UserInfo, Host, Port, _Path, _Query} ->
-	  	case S1 of
-	 	  http -> http;
-		  udp ->
-			{ok, IP} = inet:getaddr(Host, inet),
- 			{udp, IP, Port}
-		end;
-	  {error, Reason} ->
-		lager:error("Unknown URL type for url ~s, error: ~p", [Url, Reason]),
-		exit(identify_url_type)
-	end.
+    case etorrent_http_uri:parse(Url) of
+        {S1, _UserInfo, Host, Port, _Path, _Query} ->
+            case S1 of
+                http ->
+                    http;
+                udp ->
+                    {udp, Host, Port}
+            end;
+        {error, Reason} ->
+            lager:error("Unknown URL type for url ~s, error: ~p",
+                        [Url, Reason]),
+            exit(identify_url_type)
+    end.
 
 %% @doc Disconnect from tracker designated by its url.
 %% <p>It is called to comply with BEP 27 Private Torrents,

--- a/test/eunit/etorrent_tracker_communication_tests.erl
+++ b/test/eunit/etorrent_tracker_communication_tests.erl
@@ -1,0 +1,17 @@
+-module(etorrent_tracker_communication_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+identify_url_type_test_() ->
+    [?_assertEqual(http,
+                   etorrent_tracker_communication:identify_url_type(
+                     "http://tracker.example.com:1234/announce")),
+     ?_assertEqual({udp, "tracker.example.com", 1234},
+                   etorrent_tracker_communication:identify_url_type(
+                     "udp://tracker.example.com:1234/announce")),
+     ?_assertExit(identify_url_type,
+                  etorrent_tracker_communication:identify_url_type(
+                    "not_a_url")),
+     ?_assertExit(identify_url_type,
+                  etorrent_tracker_communication:identify_url_type(
+                    "ftp://tracker.example.com:1234/announce"))
+    ].


### PR DESCRIPTION
Closes #26.

## Changes

**`src/etorrent_tracker_communication.erl`**

- Remove `inet:getaddr/2` from `identify_url_type/1` — pass the host string directly as `{udp, Host, Port}` instead of resolving it to an IP tuple first. This avoids a DNS lookup on every tracker contact cycle and matches the simpler contract of the function.
- Export `identify_url_type/1` under `-ifdef(TEST)` so it can be unit tested.

**`test/eunit/etorrent_tracker_communication_tests.erl`**

Add tests for the previously uncovered paths:
- HTTP URL → `http`
- UDP URL → `{udp, Host, Port}` with host as string
- Malformed URL (no scheme) → `exit(identify_url_type)`
- Unsupported scheme (`ftp://`) → `exit(identify_url_type)`