### PR TITLE
contact_tracker_udp: handle error and timeout from UDP tracker announce

### DIFF
--- a/src/etorrent_tracker_communication.erl
+++ b/src/etorrent_tracker_communication.erl
@@ -48,7 +48,7 @@
 -export([ifaddrs/0]).
 
 -ifdef(TEST).
--export([first_tracker_id/1]).
+-export([first_tracker_id/1, contact_tracker_udp/6, test_state/4]).
 -endif.
 
 -type tier() :: [{integer(), binary()}].
@@ -284,7 +284,7 @@ format_ipv6_address(Tuple) ->
              "~4.16.0B:~4.16.0B:~4.16.0B:~4.16.0B",
     iolist_to_binary(io_lib:format(Format, tuple_to_list(Tuple))).
 
-contact_tracker_udp(Url, _TrackerID, TrackerIP, TrackerPort, Event,
+contact_tracker_udp(Url, TrackerID, TrackerIP, TrackerPort, Event,
                     #state { torrent_id = Id,
                              info_hash = InfoHash,
                              peer_id = PeerId,
@@ -318,9 +318,16 @@ contact_tracker_udp(Url, _TrackerID, TrackerIP, TrackerPort, Event,
            Timeout) of
         {ok, Peers, Status} ->
             lager:debug("UDP reply handled"),
-            {Interval, MinInterval} = 
+            {Interval, MinInterval} =
                 handle_udp_response(Url, Id, Peers, Status),
-            {ok, handle_timeout(Interval, MinInterval, S)}
+            {ok, handle_timeout(Interval, MinInterval, S)};
+        {error, Reason} ->
+            etorrent_tracker:statechange(TrackerID, [{message, error, Reason}]),
+            error;
+        timeout ->
+            etorrent_tracker:statechange(TrackerID,
+                                         [{message, error, <<"Timeout.">>}]),
+            error
     end.
 
 %% @todo: consider not passing around the state here!
@@ -495,5 +502,11 @@ first_tracker_id_test_() ->
                    first_tracker_id([[{10,"http://bt3.rutracker.org/ann?uk=xxxxxxxxxx"}],
                                      [{11,"http://retracker.local/announce"}]]))
     ].
+
+test_state(TorrentId, InfoHash, PeerId, Timeout) ->
+    #state{torrent_id = TorrentId,
+           info_hash  = InfoHash,
+           peer_id    = PeerId,
+           udp_tracker_connection_timeout = Timeout}.
 
 -endif.

--- a/test/eunit/etorrent_tracker_communication_tests.erl
+++ b/test/eunit/etorrent_tracker_communication_tests.erl
@@ -1,0 +1,45 @@
+-module(etorrent_tracker_communication_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+contact_tracker_udp_test_() ->
+    {foreach,
+     fun() ->
+         meck:new(etorrent_torrent,         [passthrough]),
+         meck:new(etorrent_config,          [passthrough]),
+         meck:new(etorrent_udp_tracker_mgr, [passthrough]),
+         meck:new(etorrent_tracker,         [passthrough]),
+         meck:expect(etorrent_torrent, lookup, fun(_Id) ->
+             {value, [{uploaded, 0}, {downloaded, 0}, {left_or_skipped, 0}]}
+         end),
+         meck:expect(etorrent_config, listen_port, fun() -> 6881 end),
+         meck:expect(etorrent_tracker, statechange, fun(_Id, _Changes) -> ok end)
+     end,
+     fun(_) ->
+         meck:unload(etorrent_torrent),
+         meck:unload(etorrent_config),
+         meck:unload(etorrent_udp_tracker_mgr),
+         meck:unload(etorrent_tracker)
+     end,
+     [?_test(begin
+         meck:expect(etorrent_udp_tracker_mgr, announce,
+                     fun(_Addr, _Props, _Timeout) -> {error, <<"connect failed">>} end),
+         S = etorrent_tracker_communication:test_state(1, <<"hash">>, <<"peer">>, 5000),
+         ?assertEqual(error,
+                      etorrent_tracker_communication:contact_tracker_udp(
+                        "udp://tracker.example.com:1234", 42,
+                        {1,2,3,4}, 1234, started, S)),
+         ?assert(meck:called(etorrent_tracker, statechange,
+                             [42, [{message, error, <<"connect failed">>}]]))
+     end),
+      ?_test(begin
+         meck:expect(etorrent_udp_tracker_mgr, announce,
+                     fun(_Addr, _Props, _Timeout) -> timeout end),
+         S = etorrent_tracker_communication:test_state(1, <<"hash">>, <<"peer">>, 5000),
+         ?assertEqual(error,
+                      etorrent_tracker_communication:contact_tracker_udp(
+                        "udp://tracker.example.com:1234", 42,
+                        {1,2,3,4}, 1234, started, S)),
+         ?assert(meck:called(etorrent_tracker, statechange,
+                             [42, [{message, error, <<"Timeout.">>}]]))
+     end)
+    ]}.


### PR DESCRIPTION
Closes #28.

## Changes

**`src/etorrent_tracker_communication.erl`**

- Add `{error, Reason}` and `timeout` clauses to `contact_tracker_udp/6`. Previously both fell through to a `case_clause` crash. They now report via `etorrent_tracker:statechange/2` and return `error`, consistent with the HTTP tracker path in `contact_tracker_http/4`.
- Fix the `_TrackerID` binding (was ignored, preventing error reporting).
- Export `contact_tracker_udp/6` and `test_state/4` under `-ifdef(TEST)`.

**`test/eunit/etorrent_tracker_communication_tests.erl`**

- EUnit tests covering the `{error, Reason}` and `timeout` paths, using meck to mock `etorrent_udp_tracker_mgr` and verify `etorrent_tracker:statechange/2` is called with the correct arguments.

This is a backport of the fix already present in the `next` branch, with test coverage added.