### PR TITLE
Backport remaining next branch fixes: contact_tracker return values, url default, tier type

### DIFF
--- a/src/etorrent_tracker_communication.erl
+++ b/src/etorrent_tracker_communication.erl
@@ -51,13 +51,13 @@
 -export([first_tracker_id/1]).
 -endif.
 
--type tier() :: [{integer(), binary()}].
+-type tier() :: etorrent_types:tier().
 -record(state, {queued_message = none :: none | started,
                 %% The hard timer is the time we *must* wait on the tracker.
                 %% soft timer may be overridden if we want to change state.
                 soft_timer     :: reference() | none,
                 hard_timer     :: reference() | none,
-                url = []     :: [tier()],
+                url = [[]]   :: [tier()],
                 info_hash      :: binary(),
                 peer_id        :: binary(),
                 control_pid    :: pid(),
@@ -179,12 +179,15 @@ contact_tracker(S) ->
     contact_tracker(none, S).
 
 contact_tracker(Event, #state { url = Tiers } = S) ->
-    contact_tracker(Tiers, Event, S).
+    case contact_tracker(Tiers, Event, S) of
+        {none, NS} -> NS;
+        {ok, NS}   -> NS
+    end.
 
 contact_tracker(Tiers, Event, S) ->
     case contact_tracker(Tiers, Event, S, []) of
-        none     -> handle_timeout(S);
-        {ok, NS} -> NS
+        none     -> {none, handle_timeout(S)};
+        {ok, NS} -> {ok, NS}
     end.
 
 -spec contact_tracker(Tiers, Event, State, Acc) -> {ok, State} | none when


### PR DESCRIPTION
Closes #30.

Backports three changes from the `next` branch with no test changes required.

**`contact_tracker/2`**: add explicit unwrapping of `{none, NS}` / `{ok, NS}` from `contact_tracker/3`. Previously the inner function returned a raw state on `none` and `{ok, State}` on success, making the return type inconsistent. The `next` branch introduced tagged tuples at the inner level and unwraps them at the outer level, which is cleaner and easier to follow.

**`url = [[]]`**: fix the default value of the `url` field in `#state{}` from `[]` to `[[]]`. The tier iteration logic expects a list of tiers (each tier being a list of trackers). An empty list skips iteration entirely; a list with one empty tier is the correct empty state.

**`-type tier()`**: reference `etorrent_types:tier()` instead of a local inline definition.