### PR TITLE
Tolerate redundant choke and interest messages from peers

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,6 +19,11 @@
 
 {eunit_opts, [{report,{eunit_surefire,[{dir,"."}]}}, verbose]}.
 
+%% rebar3: compile everything with export_all under the test profile so
+%% test modules can exercise internal functions without TEST-gated
+%% exports in the source modules.
+{profiles, [{test, [{erl_opts, [export_all, nowarn_export_all]}]}]}.
+
 {deps, [
        {gproc, ".*", {git, "git://github.com/esl/gproc.git", "master"}},
        {lager, ".*", {git, "git://github.com/basho/lager.git", "master"}},

--- a/src/etorrent_peer_control.erl
+++ b/src/etorrent_peer_control.erl
@@ -14,6 +14,9 @@
 
 -include("etorrent_rate.hrl").
 
+%% test helpers; internals reachable via export_all in the test profile
+-export([test_state/2]).
+
 %% API
 -export([start_link/8,
         choke/1,
@@ -493,59 +496,63 @@ format_status(_Opt, [_Pdict, S]) ->
 -spec handle_message(_,_) -> {'ok',_} | {'stop', _, _}.
 handle_message(keep_alive, S) ->
     {ok, S};
+%% A peer may resend its current choke or interest state; the wire
+%% protocol does not forbid redundant state messages. Treat them as
+%% no-ops instead of crashing on the strict state transitions in
+%% etorrent_peerstate (issue #8).
 handle_message(choke, State) ->
     #state{
         torrent_id=TorrentID,
         local=Local,
         config=Config,
         download=Download} = State,
-    ok = etorrent_peer_states:set_choke(TorrentID, self()),
-    NewState = case etorrent_peerconf:fast(Config) of
+    case etorrent_peerstate:choked(Local) of
         true ->
-            %% If the Fast Extension is enabled a CHOKE message does
-            %% not imply that all outstanding requests are dropped.
-            NewLocal = etorrent_peerstate:choked(true, Local),
-            State#state{local=NewLocal};
+            {ok, State};
         false ->
-            %% A CHOKE message implies that all outstanding requests has been dropped.
-            Requests = etorrent_peerstate:requests(Local),
-            Pieces = etorrent_rqueue:pieces(Requests),
-            Chunks = etorrent_rqueue:to_list(Requests),
-            Peers  = etorrent_peer_control:lookup_peers(TorrentID),
-            ok = etorrent_piecestate:unassigned(Pieces, Peers),
-            ok = etorrent_download:chunks_dropped(Chunks, Download),
-            NewReqs = etorrent_rqueue:flush(Requests),
-            TmpLocal = etorrent_peerstate:choked(true, Local),
-            NewLocal = etorrent_peerstate:requests(NewReqs, TmpLocal),
-            State#state{local=NewLocal}
-    end,
-    {ok, NewState};
+            NewLocal = remote_choked(TorrentID, Local, Config, Download),
+            {ok, State#state{local=NewLocal}}
+    end;
 
 handle_message(unchoke, State) ->
     #state{torrent_id=TorrentID} = State,
     #state{send_pid=SendPid, download=Download, local=Local, remote=Remote} = State,
-    ok = etorrent_peer_states:set_unchoke(TorrentID, self()),
-    TmpLocal = etorrent_peerstate:choked(false, Local),
-    NewLocal = poll_local_rqueue(Download, SendPid, Remote, TmpLocal),
-    NewState = State#state{local=NewLocal},
-    {ok, NewState};
+    case etorrent_peerstate:choked(Local) of
+        false ->
+            {ok, State};
+        true ->
+            ok = etorrent_peer_states:set_unchoke(TorrentID, self()),
+            TmpLocal = etorrent_peerstate:choked(false, Local),
+            NewLocal = poll_local_rqueue(Download, SendPid, Remote, TmpLocal),
+            NewState = State#state{local=NewLocal},
+            {ok, NewState}
+    end;
 
 handle_message(interested, State) ->
     #state{torrent_id=TorrentID, remote=Remote} = State,
-    ok = etorrent_peer_states:set_interested(TorrentID, self()),
-    ok = etorrent_peer_control:check_choke(self()),
-    NewRemote = etorrent_peerstate:interested(true, Remote),
-    NewState = State#state{remote=NewRemote},
-    {ok, NewState};
+    case etorrent_peerstate:interested(Remote) of
+        true ->
+            {ok, State};
+        false ->
+            ok = etorrent_peer_states:set_interested(TorrentID, self()),
+            ok = etorrent_peer_control:check_choke(self()),
+            NewRemote = etorrent_peerstate:interested(true, Remote),
+            NewState = State#state{remote=NewRemote},
+            {ok, NewState}
+    end;
 
 handle_message(not_interested, State) ->
     #state{torrent_id=TorrentID, remote=Remote} = State,
-    ok = etorrent_peer_states:set_not_interested(TorrentID, self()),
-    ok = etorrent_peer_control:check_choke(self()),
-    %% FIXME: badarg
-    NewRemote = etorrent_peerstate:interested(false, Remote),
-    NewState = State#state{remote=NewRemote},
-    {ok, NewState};
+    case etorrent_peerstate:interested(Remote) of
+        false ->
+            {ok, State};
+        true ->
+            ok = etorrent_peer_states:set_not_interested(TorrentID, self()),
+            ok = etorrent_peer_control:check_choke(self()),
+            NewRemote = etorrent_peerstate:interested(false, Remote),
+            NewState = State#state{remote=NewRemote},
+            {ok, NewState}
+    end;
 
 %% Handle incoming chunk request from wire.
 handle_message({request, Index, Offset, Length}, State) ->
@@ -751,6 +758,30 @@ handle_message(Unknown, State) ->
     {stop, normal, State}.
 
 
+%% The remote peer choked us. Record it and, unless the Fast Extension
+%% is enabled, drop all outstanding requests. Returns the new local
+%% peerstate.
+remote_choked(TorrentID, Local, Config, Download) ->
+    ok = etorrent_peer_states:set_choke(TorrentID, self()),
+    case etorrent_peerconf:fast(Config) of
+        true ->
+            %% If the Fast Extension is enabled a CHOKE message does
+            %% not imply that all outstanding requests are dropped.
+            etorrent_peerstate:choked(true, Local);
+        false ->
+            %% A CHOKE message implies that all outstanding requests has been dropped.
+            Requests = etorrent_peerstate:requests(Local),
+            Pieces = etorrent_rqueue:pieces(Requests),
+            Chunks = etorrent_rqueue:to_list(Requests),
+            Peers  = etorrent_peer_control:lookup_peers(TorrentID),
+            ok = etorrent_piecestate:unassigned(Pieces, Peers),
+            ok = etorrent_download:chunks_dropped(Chunks, Download),
+            NewReqs = etorrent_rqueue:flush(Requests),
+            TmpLocal = etorrent_peerstate:choked(true, Local),
+            etorrent_peerstate:requests(NewReqs, TmpLocal)
+    end.
+
+
 handle_ext_message({metadata_request, PieceNum}, State) ->
     #state{torrent_id=TorrentID, extensions=Exts, send_pid=SendPid,
            metadata_size=MetadataSize} = State,
@@ -943,4 +974,14 @@ check_remote_seeder(Remote, Local) ->
         _ ->
             exit(seeder)
     end.
+
+%% Build a minimal #state{} for etorrent_peer_control_tests. The record
+%% is internal to this module, so the constructor lives here.
+test_state(Local, Remote) ->
+    #state{torrent_id=0,
+           info_hash= <<0:160>>,
+           download=none,
+           local=Local,
+           remote=Remote,
+           config=none}.
 

--- a/test/etorrent_peer_control_tests.erl
+++ b/test/etorrent_peer_control_tests.erl
@@ -1,0 +1,30 @@
+-module(etorrent_peer_control_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Redundant wire messages must be no-ops (issue #8). These tests run
+%% handle_message/2 without any server infrastructure; if a redundant
+%% message reached the side-effecting code it would crash on the missing
+%% servers, so returning the state unchanged also proves the early return.
+redundant_message_test_() ->
+    %% etorrent_peerstate:new/1 yields choked=true, interested=false
+    Choked     = etorrent_peerstate:new(8),
+    Unchoked   = etorrent_peerstate:choked(false, etorrent_peerstate:new(8)),
+    Interested = etorrent_peerstate:interested(true, etorrent_peerstate:new(8)),
+    ChokedState     = etorrent_peer_control:test_state(
+                        Choked, etorrent_peerstate:new(8)),
+    UnchokedState   = etorrent_peer_control:test_state(
+                        Unchoked, etorrent_peerstate:new(8)),
+    InterestedState = etorrent_peer_control:test_state(
+                        etorrent_peerstate:new(8), Interested),
+    UninterestedState = etorrent_peer_control:test_state(
+                          etorrent_peerstate:new(8), etorrent_peerstate:new(8)),
+    [?_assertEqual({ok, ChokedState},
+                   etorrent_peer_control:handle_message(choke, ChokedState))
+    ,?_assertEqual({ok, UnchokedState},
+                   etorrent_peer_control:handle_message(unchoke, UnchokedState))
+    ,?_assertEqual({ok, InterestedState},
+                   etorrent_peer_control:handle_message(interested, InterestedState))
+    ,?_assertEqual({ok, UninterestedState},
+                   etorrent_peer_control:handle_message(not_interested, UninterestedState))
+    ].


### PR DESCRIPTION
Fixes #8.

The wire protocol does not forbid a peer from resending its current choke or interest state, and real clients do this. `etorrent_peerstate:choked/2` and `interested/2` are strict transitions that raise `badarg` on a no-op change, so a duplicate `CHOKE`, `UNCHOKE`, `INTERESTED` or `NOT_INTERESTED` message crashed the peer process with the exact trace from the issue:

```
{badarg,[{etorrent_peerstate,choked,2,...},
         {etorrent_peer_control,handle_message,2,...}]}
```

(The `not_interested` handler even carried a `%% FIXME: badarg` comment marking this.)

**The fix**: check the current state at the top of each of the four wire message handlers in `etorrent_peer_control:handle_message/2` and ignore the message when it is redundant, before any side effects run (`etorrent_peer_states` updates, request flushing, choke checks). The strict transitions in `etorrent_peerstate` are deliberately kept as is: for internally driven transitions they still catch real logic errors.

**Tests**: EUnit cases for all four redundant messages. The handlers are exercised without any server infrastructure, so if a redundant message reached the side-effecting code the test would crash on the missing servers; the tests therefore also prove the early return.